### PR TITLE
Always try to close a port before opening. 

### DIFF
--- a/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
+++ b/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
@@ -399,6 +399,7 @@ public class GenericGcodeDriver extends LaserCutter {
     return null;
   }
   
+  @SuppressWarnings("empty-statement")
   protected String connect_serial(CommPortIdentifier i, ProgressListener pl) throws PortInUseException, IOException, UnsupportedCommOperationException
   {
     pl.taskChanged(this, "opening '"+i.getName()+"'");
@@ -406,6 +407,16 @@ public class GenericGcodeDriver extends LaserCutter {
     {
       try
       {
+        try
+        {
+          in.close();
+          out.close();
+          port.close();
+        }
+        catch (Exception e)
+        { } //do nothing
+       
+       
         port = i.open("VisiCut", 1000);
         try
         {


### PR DESCRIPTION
This takes care of serial ports being locked open when an error occurs during a run.