### PR TITLE
Marlin driver update

### DIFF
--- a/src/com/t_oster/liblasercut/drivers/Marlin.java
+++ b/src/com/t_oster/liblasercut/drivers/Marlin.java
@@ -40,7 +40,8 @@ public class Marlin extends GenericGcodeDriver {
     setLineend("CRLF");
     setInitDelay(0);
     setPreJobGcode(getPreJobGcode()+",G28 XY,M5");
-    setPostJobGcode(getPostJobGcode()+",G28 XY,M5");
+    setPostJobGcode(getPostJobGcode()+",M5,G28 XY");
+    setSerialTimeout(35000);
     
     //Marlin has no way to upload over the network so remove the upload url text
     setHttpUploadUrl("");

--- a/src/com/t_oster/liblasercut/drivers/Marlin.java
+++ b/src/com/t_oster/liblasercut/drivers/Marlin.java
@@ -38,8 +38,8 @@ public class Marlin extends GenericGcodeDriver {
     setWaitForOKafterEachLine(true);
     setBaudRate(115200);
     setLineend("CRLF");
-    setInitDelay(10);
-    setPreJobGcode(getPreJobGcode()+",G28 XY,M3");
+    setInitDelay(0);
+    setPreJobGcode(getPreJobGcode()+",G28 XY,M5");
     setPostJobGcode(getPostJobGcode()+",G0 X0Y0,M5");
     
     //Marlin has no way to upload over the network so remove the upload url text

--- a/src/com/t_oster/liblasercut/drivers/Marlin.java
+++ b/src/com/t_oster/liblasercut/drivers/Marlin.java
@@ -40,7 +40,7 @@ public class Marlin extends GenericGcodeDriver {
     setLineend("CRLF");
     setInitDelay(0);
     setPreJobGcode(getPreJobGcode()+",G28 XY,M5");
-    setPostJobGcode(getPostJobGcode()+",G0 X0Y0,M5");
+    setPostJobGcode(getPostJobGcode()+",G28 XY,M5");
     
     //Marlin has no way to upload over the network so remove the upload url text
     setHttpUploadUrl("");
@@ -60,7 +60,6 @@ public class Marlin extends GenericGcodeDriver {
     result.addAll(Arrays.asList(super.getPropertyKeys()));
     result.remove(GenericGcodeDriver.SETTING_IDENTIFICATION_STRING);
     result.remove(GenericGcodeDriver.SETTING_WAIT_FOR_OK);
-    result.remove(GenericGcodeDriver.SETTING_BAUDRATE);
     result.remove(GenericGcodeDriver.SETTING_LINEEND);
     result.remove(GenericGcodeDriver.SETTING_INIT_DELAY);
     result.remove(GenericGcodeDriver.SETTING_HTTP_UPLOAD_URL);


### PR DESCRIPTION
Some improvements to the Marlin driver

* moved the M5 to before homing to remove the possibility of a big line going through the material while homing
* changed from G0X0Y0 to G28 as a safety measure. it can crash if a job is started before the PSU is turned on
* no need for an init delay so it is now 0
* set higher serial timeout