### PR TITLE
Fix Smoothieboard not responding when connected via serial

### DIFF
--- a/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
+++ b/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
@@ -503,6 +503,7 @@ public class GenericGcodeDriver extends LaserCutter {
         {
           SerialPort sp = (SerialPort) port;
           sp.setSerialPortParams(getBaudRate(), 8, 1, 0);
+          sp.setDTR(true);
         }
         out = new PrintStream(port.getOutputStream(), true, "US-ASCII");
         in = new BufferedReader(new InputStreamReader(port.getInputStream()));


### PR DESCRIPTION
See https://github.com/t-oster/VisiCut/issues/332

This hasn't been tested on any other platform or hardware. It's also at the generic gcode driver level, which might not be appropriate. That said, this doesn't seem like it could cause much in the way of adverse behaviour.