### PR TITLE
Fix power command missing on subsequent gcode exports after initial export

### DIFF
--- a/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
+++ b/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
@@ -688,6 +688,9 @@ public class GenericGcodeDriver extends LaserCutter {
 
 @Override
 public void saveJob(java.io.PrintStream fileOutputStream, LaserJob job) throws IllegalJobException, Exception {
+  this.currentPower = -1;
+  this.currentSpeed = -1;
+  
 	checkJob(job);
 
 	this.out = fileOutputStream;


### PR DESCRIPTION
Using File > Export Laser Gcode gives this on the first run (20mm red circle example on a Grbl based cutter):

```
G21
G90
M3 S0
G0 X21.539200 Y11.226800 F3600
G1 X21.488400 Y12.242800 S1.000000 F50
G1 X21.336000 Y13.258800
```

However if you immediately export it again without changing the power, you get this:

```
G21
G90
M3 S0
G0 X21.539200 Y11.226800 F3600
G1 X21.488400 Y12.242800 F50
G1 X21.336000 Y13.258800
```

Note the missing `S1.000000` command, since `currentPower` hasn't changed from the previous run.