### PR TITLE
Turn laser off when doing G0 rapids

### DIFF
--- a/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
+++ b/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
@@ -362,7 +362,8 @@ public class GenericGcodeDriver extends LaserCutter {
     x = isFlipXaxis() ? getBedWidth() - Util.px2mm(x, resolution) : Util.px2mm(x, resolution);
     y = isFlipYaxis() ? getBedHeight() - Util.px2mm(y, resolution) : Util.px2mm(y, resolution);
     currentSpeed = getTravel_speed();
-    sendLine("G0 X%f Y%f F%d", x, y, (int) (travel_speed));
+    currentPower = 0.0;
+    sendLine("G0 X%f Y%f S0 F%d", x, y, (int) (travel_speed));
   }
 
   protected void line(PrintStream out, double x, double y, double resolution) throws IOException {


### PR DESCRIPTION
Currently the laser is kepy on during G0 rapids.

E.g. two 20mm rectangles next to each other on a grbl:

```
G21
G90
M3 S0
; move to first box
G0 X2.997200 Y2.997200 F3600
; cut first box
G1 X22.961600 Y2.997200 S1.000000 F50
G1 X22.961600 Y22.961600
G1 X2.997200 Y22.961600
G1 X2.997200 Y2.997200
G1 X2.997200 Y2.997200
; move to second box
G0 X29.972000 Y2.997200 F3600
; cut second box
G1 X49.987200 Y2.997200 F50
G1 X49.987200 Y22.961600
G1 X29.972000 Y22.961600
G1 X29.972000 Y2.997200
G1 X29.972000 Y2.997200
M5
G0 X0 Y0
```

The laser is kept on while moving around. Not really an issue unless you have a really powerful laser or are cutting paper.

This commit changes it to turn off the laser during moves:

```
G21
G90
M3 S0
; move to first box
G0 X2.997200 Y2.997200 S0 F3600
; cut first box
G1 X22.961600 Y2.997200 S1.000000 F50
G1 X22.961600 Y22.961600
G1 X2.997200 Y22.961600
G1 X2.997200 Y2.997200
G1 X2.997200 Y2.997200
; move to second box
G0 X29.972000 Y2.997200 S0 F3600
; cut second box
G1 X49.987200 Y2.997200 S1.000000 F50
G1 X49.987200 Y22.961600
G1 X29.972000 Y22.961600
G1 X29.972000 Y2.997200
G1 X29.972000 Y2.997200
M5
G0 X0 Y0
```

Does this seem correct? Or is will it cause issues with non-laser-mode firmwares (e.g. stock grbl) that assume the spindle has inertia and requires a dwell to get up to speed?