### PR TITLE
Add configurable option to blank laser during G0 rapid moves.

### DIFF
--- a/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
+++ b/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
@@ -64,7 +64,7 @@ public class GenericGcodeDriver extends LaserCutter {
   protected static final String SETTING_WAIT_FOR_OK = "Wait for OK after each line (interactive mode)";
   protected static final String SETTING_INIT_DELAY = "Seconds to wait for board reset (Serial)";
   protected static final String SETTING_SERIAL_TIMEOUT = "Milliseconds to wait for response";
-  protected static final String SETTING_BLANK_LASER_DURING_RAPIDS = "Blank laser during non-laser moves";
+  protected static final String SETTING_BLANK_LASER_DURING_RAPIDS = "Force laser off during G0 moves";
   
   protected static Locale FORMAT_LOCALE = Locale.US;
   

--- a/src/com/t_oster/liblasercut/drivers/Marlin.java
+++ b/src/com/t_oster/liblasercut/drivers/Marlin.java
@@ -42,6 +42,7 @@ public class Marlin extends GenericGcodeDriver {
     setPreJobGcode(getPreJobGcode()+",G28 XY,M5");
     setPostJobGcode(getPostJobGcode()+",M5,G28 XY");
     setSerialTimeout(35000);
+    setBlankLaserDuringRapids(false);
     
     //Marlin has no way to upload over the network so remove the upload url text
     setHttpUploadUrl("");
@@ -65,6 +66,7 @@ public class Marlin extends GenericGcodeDriver {
     result.remove(GenericGcodeDriver.SETTING_INIT_DELAY);
     result.remove(GenericGcodeDriver.SETTING_HTTP_UPLOAD_URL);
     result.remove(GenericGcodeDriver.SETTING_HOST);
+    result.remove(GenericGcodeDriver.SETTING_BLANK_LASER_DURING_RAPIDS);
     return result.toArray(new String[0]);
   }
   

--- a/src/com/t_oster/liblasercut/drivers/SmoothieBoard.java
+++ b/src/com/t_oster/liblasercut/drivers/SmoothieBoard.java
@@ -40,6 +40,7 @@ public class SmoothieBoard extends GenericGcodeDriver {
     setInitDelay(0);
     setPreJobGcode(getPreJobGcode()+",M3");
     setPostJobGcode(getPostJobGcode()+",M5");
+    setBlankLaserDuringRapids(false);
   }
   
   @Override
@@ -77,6 +78,7 @@ public class SmoothieBoard extends GenericGcodeDriver {
     result.remove(GenericGcodeDriver.SETTING_BAUDRATE);
     result.remove(GenericGcodeDriver.SETTING_LINEEND);
     result.remove(GenericGcodeDriver.SETTING_INIT_DELAY);
+    result.remove(GenericGcodeDriver.SETTING_BLANK_LASER_DURING_RAPIDS);
     return result.toArray(new String[0]);
   }
 


### PR DESCRIPTION
 Fixes issues in PR #38 for Smoothie boards.

Example Gcode output for different boards with this modification, when cutting two 20mm square boxes:

**Generic Gcode driver, setting disabled (default)**
```
G21
G90
M3
G0 X0.000000 Y0.000000 F3600
G1 X19.964400 Y0.000000 S1.000000 F500
G1 X19.964400 Y19.964400
G1 X0.000000 Y19.964400
G1 X0.000000 Y0.000000
G1 X0.000000 Y0.000000
G0 X24.993600 Y0.000000 F3600
G1 X44.958000 Y0.000000 S0.200000 F500
G1 X44.958000 Y19.964400
G1 X24.993600 Y19.964400
G1 X24.993600 Y0.000000
G1 X24.993600 Y0.000000
M5
G0 X0 Y150
```

**Generic Gcode driver, setting enabled**
```
G21
G90
M3
G0 X0.000000 Y0.000000 F3600 S0
G1 X19.964400 Y0.000000 S1.000000 F500
G1 X19.964400 Y19.964400
G1 X0.000000 Y19.964400
G1 X0.000000 Y0.000000
G1 X0.000000 Y0.000000
G0 X24.993600 Y0.000000 F3600 S0
G1 X44.958000 Y0.000000 S0.200000 F500
G1 X44.958000 Y19.964400
G1 X24.993600 Y19.964400
G1 X24.993600 Y0.000000
G1 X24.993600 Y0.000000
M5
G0 X0 Y150
```

**Marlin output for same file**
```
G21
G90
G28 XY
M5
G0 X0.000000 Y0.000000 F3600
G1 X19.964400 Y0.000000 S100.000000 F1200
G1 X19.964400 Y19.964400
G1 X0.000000 Y19.964400
G1 X0.000000 Y0.000000
G1 X0.000000 Y0.000000
G0 X24.993600 Y0.000000 F3600
G1 X44.958000 Y0.000000 S20.000000 F1200
G1 X44.958000 Y19.964400
G1 X24.993600 Y19.964400
G1 X24.993600 Y0.000000
G1 X24.993600 Y0.000000
G0 X0 Y0
M5
G28 XY
```

**SmoothieBoard output for same file**
```
G21
G90
M3
G0 X0.000000 Y0.000000 F3600
G1 X19.964400 Y0.000000 S1.000000 F1200
G1 X19.964400 Y19.964400
G1 X0.000000 Y19.964400
G1 X0.000000 Y0.000000
G1 X0.000000 Y0.000000
G0 X24.993600 Y0.000000 F3600
G1 X44.958000 Y0.000000 S0.200000 F1200
G1 X44.958000 Y19.964400
G1 X24.993600 Y19.964400
G1 X24.993600 Y0.000000
G1 X24.993600 Y0.000000
G0 X0 Y0
M5
```

The `S0` parameters are only added when using the base generic driver and only when the setting is enabled. The Marlin and Smoothie classes now again output `G0` moves without any `Sx` parameter.