### PR TITLE
Add configurable S parameter for 100% power. 

### DIFF
--- a/src/com/t_oster/liblasercut/LaserCutter.java
+++ b/src/com/t_oster/liblasercut/LaserCutter.java
@@ -228,6 +228,29 @@ public abstract class LaserCutter implements Cloneable, Customizable {
       }
     }
     
+    /**
+     * Adjust defaults after deserializing driver from XML
+     * Use this if you add new fields to a driver and need them to be properly
+     * initialized to *non-falsy* values before use.
+     * 
+     * i.e. you add a new key that by default isn't 0/0.0/false/"". Without
+     * adding a default in here, then no matter what your constructor/initializer
+     * does, it will always be set to a falsey value after deserializing an old
+     * XML file.
+     */
+    protected void setKeysMissingFromDeserialization()
+    {
+    }
+    
     @Override
     public abstract LaserCutter clone();
+  
+    /**
+     * Called by XStream when deserializing XML settings files. Hook here to
+     * call setKeysMissingFromDeserialization.
+     */
+    private Object readResolve() {
+      setKeysMissingFromDeserialization();
+      return this;
+    }
 }

--- a/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
+++ b/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
@@ -69,7 +69,7 @@ public class GenericGcodeDriver extends LaserCutter {
   protected static final String SETTING_BLANK_LASER_DURING_RAPIDS = "Force laser off during G0 moves";
   protected static final String SETTING_FILE_EXPORT_PATH = "Path to save exported gcode";
   protected static final String SETTING_USE_BIDIRECTIONAL_RASTERING = "Use bidirectional rastering";
-  protected static final String SETTING_SPINDLE_MAX = "100% value for spindle";
+  protected static final String SETTING_SPINDLE_MAX = "S value for 100% laser power";
   
   protected static Locale FORMAT_LOCALE = Locale.US;
   

--- a/src/com/t_oster/liblasercut/drivers/Marlin.java
+++ b/src/com/t_oster/liblasercut/drivers/Marlin.java
@@ -43,10 +43,22 @@ public class Marlin extends GenericGcodeDriver {
     setPostJobGcode(getPostJobGcode()+",M5,G28 XY");
     setSerialTimeout(35000);
     setBlankLaserDuringRapids(false);
+    setSpindleMax(100.0); // marlin interprets power from 0-100 instead of 0-1
     
     //Marlin has no way to upload over the network so remove the upload url text
     setHttpUploadUrl("");
     setHost("");
+  }
+  
+  /**
+   * Adjust defaults after deserializing driver from an old version of XML file
+   */
+  @Override
+  protected void setKeysMissingFromDeserialization()
+  {
+    // added field spindleMax, needs to be set to 100.0 for Marlin
+    // but xstream initializes it to 0.0 when it is missing from XML
+    if (this.spindleMax <= 0.0) this.spindleMax = 100.0;
   }
   
   @Override
@@ -66,6 +78,7 @@ public class Marlin extends GenericGcodeDriver {
     result.remove(GenericGcodeDriver.SETTING_INIT_DELAY);
     result.remove(GenericGcodeDriver.SETTING_HTTP_UPLOAD_URL);
     result.remove(GenericGcodeDriver.SETTING_HOST);
+    result.remove(GenericGcodeDriver.SETTING_SPINDLE_MAX);
     result.remove(GenericGcodeDriver.SETTING_BLANK_LASER_DURING_RAPIDS);
     return result.toArray(new String[0]);
   }
@@ -92,13 +105,6 @@ public class Marlin extends GenericGcodeDriver {
         }
     }
     return null;
-  }
-
-  @Override
-  protected void setPower(double powerInPercent)
-  {
-    //marlin interprets power from 0-100 instead of 0-1
-    super.setPower(powerInPercent*100);
   }
 
   @Override

--- a/src/com/t_oster/liblasercut/drivers/SmoothieBoard.java
+++ b/src/com/t_oster/liblasercut/drivers/SmoothieBoard.java
@@ -41,6 +41,7 @@ public class SmoothieBoard extends GenericGcodeDriver {
     setPreJobGcode(getPreJobGcode()+",M3");
     setPostJobGcode(getPostJobGcode()+",M5");
     setBlankLaserDuringRapids(false);
+    setSpindleMax(1.0);
   }
   
   @Override
@@ -78,6 +79,7 @@ public class SmoothieBoard extends GenericGcodeDriver {
     result.remove(GenericGcodeDriver.SETTING_BAUDRATE);
     result.remove(GenericGcodeDriver.SETTING_LINEEND);
     result.remove(GenericGcodeDriver.SETTING_INIT_DELAY);
+    result.remove(GenericGcodeDriver.SETTING_SPINDLE_MAX);
     result.remove(GenericGcodeDriver.SETTING_BLANK_LASER_DURING_RAPIDS);
     return result.toArray(new String[0]);
   }


### PR DESCRIPTION
Different firmwares have different ideas about what `S` values constitutes 100% laser power. E.g. 
* Marlin uses 100
* Smoothie uses 1.0
* Stock Grbl and MrBeam use 1000

This PR adds a setting to the generic gcode driver to make it more versatile at generating gcode for a variety of devices. For Marlin and Smoothie, they have the setting hidden and defaults initialised to the correct values.

The only gotcha here is when loading an existing laser cutter configured in an older version of Visicut, as it won't have the `<spindleMax>` field in its XML. When xstream deserializes it, it ignores any constructor defaults, and even ignores the `protected double spindleMax = 1.0` statement. Instead it initialises this missing field to `0.0` which means your laser power will top out at... zero.

So `setKeysMissingFromDeserialization` is added as a post-deserialisation hook in order to set the missing keys to sensible defaults. On Marlin it sets it to 100, for the others it is set to 1.0.

Example gcode, the usual two 20mm boxes, one at 20%, one at 100% laser strength.

**Generic gcode driver**:
```
G21
G90
M3
G0 X0.000000 Y0.000000 F3600
G1 X19.964400 Y0.000000 S0.200000 F1200
G1 X19.964400 Y19.964400
G1 X0.000000 Y19.964400
G1 X0.000000 Y0.000000
G1 X0.000000 Y0.000000
G0 X24.993600 Y0.000000 F3600
G1 X44.958000 Y0.000000 S1.000000 F1200
G1 X44.958000 Y19.964400
G1 X24.993600 Y19.964400
G1 X24.993600 Y0.000000
G1 X24.993600 Y0.000000
G0 X0 Y0
M5
```

**Generic gcode with 1000**:
```
G21
G90
M3 S0
G0 X0.000000 Y0.000000 F3600
G1 X19.964400 Y0.000000 S250.000000 F400
G1 X19.964400 Y19.964400
G1 X0.000000 Y19.964400
G1 X0.000000 Y0.000000
G1 X0.000000 Y0.000000
G0 X24.993600 Y0.000000 F3600
G1 X44.958000 Y0.000000 S1000.000000 F500
G1 X44.958000 Y19.964400
G1 X24.993600 Y19.964400
G1 X24.993600 Y0.000000
G1 X24.993600 Y0.000000
M5
G0 X0 Y150
```

**Marlin**:
```
G21
G90
G28 XY
M5
G0 X0.000000 Y0.000000 F3600
G1 X19.964400 Y0.000000 S20.000000 F1200
G1 X19.964400 Y19.964400
G1 X0.000000 Y19.964400
G1 X0.000000 Y0.000000
G1 X0.000000 Y0.000000
G0 X24.993600 Y0.000000 F3600
G1 X44.958000 Y0.000000 S100.000000 F1200
G1 X44.958000 Y19.964400
G1 X24.993600 Y19.964400
G1 X24.993600 Y0.000000
G1 X24.993600 Y0.000000
G0 X0 Y0
M5
G28 XY
```

**Smoothie**:
```
G21
G90
M3
G0 X0.000000 Y0.000000 F3600
G1 X19.964400 Y0.000000 S0.200000 F1200
G1 X19.964400 Y19.964400
G1 X0.000000 Y19.964400
G1 X0.000000 Y0.000000
G1 X0.000000 Y0.000000
G0 X24.993600 Y0.000000 F3600
G1 X44.958000 Y0.000000 S1.000000 F1200
G1 X44.958000 Y19.964400
G1 X24.993600 Y19.964400
G1 X24.993600 Y0.000000
G1 X24.993600 Y0.000000
G0 X0 Y0
M5
```

Does anyone have a better suggestion for the settings label? Currently "100% value for spindle" which is obviously not very good. "Max S value for laser"? "Max RPM value for laser-spindle"?