### PR TITLE
Pass correct type to laser property (fixes #45)

### DIFF
--- a/src/com/t_oster/liblasercut/RasterPart.java
+++ b/src/com/t_oster/liblasercut/RasterPart.java
@@ -40,7 +40,12 @@ public class RasterPart extends RasterizableJobPart
     this.resolution = resolution;
     this.blackPixelProperty = laserProperty;
     this.whitePixelProperty = blackPixelProperty.clone();
-    whitePixelProperty.setProperty("power", 0.0f);
+    if (whitePixelProperty instanceof FloatPowerSpeedFocusFrequencyProperty || whitePixelProperty instanceof FloatPowerSpeedFocusProperty) {
+      whitePixelProperty.setProperty("power", 0.0f);
+    }
+    else {
+      whitePixelProperty.setProperty("power", 0);
+    }
   }
 
   @Override


### PR DESCRIPTION
Fixes:
```
java.lang.ClassCastException: java.lang.Float cannot be cast to java.lang.Integer
at com.t_oster.liblasercut.PowerSpeedFocusProperty.setProperty(PowerSpeedFocusProperty.java:137)
```