### PR TITLE
Replace use of LinkedList<Byte> with a wrapper around byte[]

### DIFF
--- a/src/com/t_oster/liblasercut/ByteArrayList.java
+++ b/src/com/t_oster/liblasercut/ByteArrayList.java
@@ -1,0 +1,153 @@
+/**
+ * This file is part of LibLaserCut.
+ * Copyright (C) 2016 Google Inc.
+ *
+ * LibLaserCut is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LibLaserCut is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+package com.t_oster.liblasercut;
+
+import java.util.AbstractList;
+
+/**
+ * A specialized class to support the usage of List<Byte> within this library.
+ * It is efficient for adds at the end of the list and removes from the 
+ * start or end of the list.
+ * Adds or removes in the middle of the list are not efficient, but those
+ * operations are not used in this library.
+ */
+public class ByteArrayList extends AbstractList<Byte> {
+
+  /** The underlying byte data.  */
+  private byte[] data = null;
+
+  /**
+   * The index into the underlying array for the first element of the list.
+   * This may shift as items are removed or added from the front.
+   */
+  private int start = 0;
+
+  /** Current size of data in the list */
+  private int size = 0;
+
+  /**
+   * Most uses of ByteArrayList know their size up front, but some may add
+   * a few elements onto the beginning or end.  A small additive growth is 
+   * sufficient to support them.  It is preferred for callers to hold onto
+   * and reuse the ByteArrayList to avoid reallocation.
+   */
+  private static final int GROW_SIZE = 32;
+
+  /**
+   * Create a new list for the target expected size.
+   */
+  public ByteArrayList(int expectedSize) {
+    data = new byte[expectedSize];
+  }
+
+  @Override
+  public Byte get(int index) {
+    return data[start + index];
+  }
+
+  @Override
+  public int size() {
+    return size;
+  }
+
+  @Override
+  public void add(int index, Byte v) {
+    if (start + size >= data.length) {
+      // Grow at the end
+      byte[] newdata = new byte[data.length + GROW_SIZE];
+      System.arraycopy(data, 0, newdata, 0, data.length);
+      data = newdata;
+    }
+    if (index == size) {
+      data[start + index] = v;
+      size++;
+    } else if (index == 0) {
+      if (start == 0) {
+	// Grow at the beginning
+	byte[] newdata = new byte[data.length + GROW_SIZE];
+	System.arraycopy(data, 0, newdata, GROW_SIZE, data.length);
+	data = newdata;
+	start = GROW_SIZE;
+      }
+      start--;
+      data[start] = v;
+      size++;
+    } else {
+      // Adding in the middle is inefficient, but is not actually used
+      // in this library.  This implementation is here for completeness.
+      System.arraycopy(data, start + index,
+		       data, start + index + 1, size - index);
+      data[start + index] = v;
+      size++;
+    }
+  }
+
+  @Override
+  public Byte set(int index, Byte v) {
+    byte p = data[start + index];
+    data[start + index] = v;
+    return p;
+  }
+
+  @Override
+  public Byte remove(int index) {
+    byte v = data[start + index];
+    size -= 1;
+    if (index == 0) {
+      start += 1;
+    } else if (index < size) {
+      // Removing from the middle is inefficient, but is not actually used
+      // in this library.  This implementation is here for completeness.
+      System.arraycopy(data, start + index + 1,
+		       data, start + index, size - index);
+    }
+    return v;
+  }
+
+  @Override
+  public void clear() {
+    start = 0;
+    size = 0;
+  }
+
+  /**
+   * Clear the list for a new expected size.  This will reallocate the array
+   * if needed, and also set internal state so that any extra space for growth
+   * beyond the expected size is split evenly between the beginning and end
+   * of the underlying array.
+   */
+  public void clear(int newExpectedSize) {
+    if (data.length < newExpectedSize) {
+      data = new byte[newExpectedSize];
+    }
+    start = (data.length - newExpectedSize) / 2;
+    size = 0;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder b = new StringBuilder("[");
+    for (int i = start; i < start + size; i++) {
+      b.append(data[i]+", ");
+    }
+    b.append("(" + start +" free at head, " +
+	     (data.length - start - size) + " free at tail)]");
+    return b.toString();
+  }
+}

--- a/src/com/t_oster/liblasercut/Raster3dPart.java
+++ b/src/com/t_oster/liblasercut/Raster3dPart.java
@@ -19,7 +19,6 @@
 package com.t_oster.liblasercut;
 
 import com.t_oster.liblasercut.platform.Point;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -85,13 +84,33 @@ public class Raster3dPart extends RasterizableJobPart
    * Returns one line of the given rasterpart every byte represents one pixel
    * and the value corresponds to the raster power
    *
-   * @param raster
    * @param line
    * @return
    */
   public List<Byte> getRasterLine(int line)
   {
-    List<Byte> result = new LinkedList<Byte>();
+    ByteArrayList b = new ByteArrayList(image.getWidth());
+    getRasterLine(line, b);
+    return b;
+  }
+
+  /**
+   * Sets one line of the given rasterpart in the given result list.
+   * Every byte represents one pixel and the value corresponds to the
+   * raster power.
+   * This method is preferred to the above method because it allows reuse of
+   * an allocated List<Byte> instead of reallocating for every line.
+   *
+   * @param line
+   * @param result
+   */
+  public List<Byte> getRasterLine(int line, List<Byte> result)
+  {
+    if (result instanceof ByteArrayList) {
+	((ByteArrayList)result).clear(image.getWidth());
+    } else {
+	result.clear();
+    }
     for (int x = 0; x < image.getWidth(); x++)
     {
       //TOTEST: Black white (byte converssion)
@@ -117,13 +136,23 @@ public class Raster3dPart extends RasterizableJobPart
 
   public List<Byte> getInvertedRasterLine(int line)
   {
-    List<Byte> result = new LinkedList<Byte>();
+    ByteArrayList b = new ByteArrayList(image.getWidth());
+    getInvertedRasterLine(line, b);
+    return b;
+  }
+
+  public void getInvertedRasterLine(int line, List<Byte> result)
+  {
+    if (result instanceof ByteArrayList) {
+	((ByteArrayList)result).clear(image.getWidth());
+    } else {
+	result.clear();
+    }
     for (int x = 0; x < image.getWidth(); x++)
     {
       //TOTEST: Black white (byte converssion)
       result.add((byte) (255 - image.getGreyScale(x, line)));
     }
-    return result;
   }
 
   @Override

--- a/src/com/t_oster/liblasercut/RasterPart.java
+++ b/src/com/t_oster/liblasercut/RasterPart.java
@@ -19,7 +19,6 @@
 package com.t_oster.liblasercut;
 
 import com.t_oster.liblasercut.platform.Point;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -92,12 +91,31 @@ public class RasterPart extends RasterizableJobPart
    */
   public List<Byte> getRasterLine(int line)
   {
-    List<Byte> result = new LinkedList<Byte>();
+    ByteArrayList b = new ByteArrayList((image.getWidth() + 7) / 8);
+    getRasterLine(line, b);
+    return b;
+  }
+
+  /**
+   * Sets one line of the given rasterpart into the given result list.
+   * every byte represents 8 pixel and the value corresponds to
+   * 1 when black or 0 when white
+   * This method is preferred to the above method because it allows reuse of
+   * an allocated List<Byte> instead of reallocating for every line.
+   * @param line
+   * @param result
+   */ 
+  public void getRasterLine(int line, List<Byte> result)
+  {
+    if (result instanceof ByteArrayList) {
+	((ByteArrayList)result).clear((image.getWidth() + 7) / 8);
+    } else {
+	result.clear();
+    }
     for (int x = 0; x < (image.getWidth() + 7) / 8; x++)
     {
       result.add(((BlackWhiteRaster) image).getByte(x, line));
     }
-    return result;
   }
 
   public boolean isBlack(int x, int y)

--- a/src/com/t_oster/liblasercut/drivers/GoldCutHPGL.java
+++ b/src/com/t_oster/liblasercut/drivers/GoldCutHPGL.java
@@ -233,10 +233,11 @@ public class GoldCutHPGL extends LaserCutter {
     Point rasterStart = rp.getRasterStart();
     PowerSpeedFocusProperty prop = (PowerSpeedFocusProperty) rp.getLaserProperty();
     setSpeed(out, prop.getSpeed());
+    ByteArrayList bytes = new ByteArrayList(rp.getRasterWidth());
     for (int line = 0; line < rp.getRasterHeight(); line++) {
       Point lineStart = rasterStart.clone();
       lineStart.y += line;
-      List<Byte> bytes = rp.getRasterLine(line);
+      rp.getRasterLine(line, bytes);
       //remove heading zeroes
       while (bytes.size() > 0 && bytes.get(0) == 0) {
         bytes.remove(0);

--- a/src/com/t_oster/liblasercut/drivers/LaosCutter.java
+++ b/src/com/t_oster/liblasercut/drivers/LaosCutter.java
@@ -18,6 +18,7 @@
  **/
 package com.t_oster.liblasercut.drivers;
 
+import com.t_oster.liblasercut.ByteArrayList;
 import com.t_oster.liblasercut.IllegalJobException;
 import com.t_oster.liblasercut.JobPart;
 import com.t_oster.liblasercut.LaserCutter;
@@ -444,11 +445,12 @@ public class LaosCutter extends LaserCutter
     this.setCurrentProperty(out, prop);
     float maxPower = this.currentPower;
     boolean bu = prop.isEngraveBottomUp();
+    ByteArrayList bytes = new ByteArrayList(rp.getRasterWidth());
     for (int line = bu ? rp.getRasterHeight()-1 : 0; bu ? line >= 0 : line < rp.getRasterHeight(); line += bu ? -1 : 1 )
     {
       Point lineStart = rasterStart.clone();
       lineStart.y += line;
-      List<Byte> bytes = rp.getRasterLine(line);
+      rp.getRasterLine(line, bytes);
       //remove heading zeroes
       while (bytes.size() > 0 && bytes.get(0) == 0)
       {
@@ -575,11 +577,12 @@ public class LaosCutter extends LaserCutter
     LaosEngraveProperty prop = rp.getLaserProperty() instanceof LaosEngraveProperty ? (LaosEngraveProperty) rp.getLaserProperty() : new LaosEngraveProperty(rp.getLaserProperty());
     this.setCurrentProperty(out, prop);
     boolean bu = prop.isEngraveBottomUp();
+    ByteArrayList bytes = new ByteArrayList(rp.getRasterWidth());
     for (int line = bu ? rp.getRasterHeight()-1 : 0; bu ? line >= 0 : line < rp.getRasterHeight(); line += bu ? -1 : 1)
     {
       Point lineStart = rasterStart.clone();
       lineStart.y += line;
-      List<Byte> bytes = rp.getRasterLine(line);
+      rp.getRasterLine(line, bytes);
       //remove heading zeroes
       while (bytes.size() > 0 && bytes.get(0) == 0)
       {

--- a/src/com/t_oster/liblasercut/drivers/Lasersaur.java
+++ b/src/com/t_oster/liblasercut/drivers/Lasersaur.java
@@ -203,10 +203,11 @@ public class Lasersaur extends LaserCutter {
     Point rasterStart = rp.getRasterStart();
     PowerSpeedFocusProperty prop = (PowerSpeedFocusProperty) rp.getLaserProperty();
     setSpeed(out, prop.getSpeed());
+    ByteArrayList bytes = new ByteArrayList(rp.getRasterWidth());
     for (int line = 0; line < rp.getRasterHeight(); line++) {
       Point lineStart = rasterStart.clone();
       lineStart.y += line;
-      List<Byte> bytes = rp.getRasterLine(line);
+      rp.getRasterLine(line, bytes);
       //remove heading zeroes
       while (bytes.size() > 0 && bytes.get(0) == 0) {
         bytes.remove(0);


### PR DESCRIPTION
This makes handling of raster3d jobs much faster, and uses less memory allocation with less GC churn.
The amount of speedup depends on the size of the job.  For a 20x30cm 1000dpi job there was a 100x speedup.  For a full 40x60cm job it completed in 2 seconds, whereas before it still wasn't complete after half an hour.