### PR TITLE
Remove trailing zeros from raster3d generation.

### DIFF
--- a/src/com/t_oster/liblasercut/drivers/EpilogCutter.java
+++ b/src/com/t_oster/liblasercut/drivers/EpilogCutter.java
@@ -477,6 +477,11 @@ abstract class EpilogCutter extends LaserCutter
           line.remove(0);
           jump++;
         }
+        //Remove trailing zeroes
+        while (line.size() > 0 && line.get(line.size()-1) == 0)
+        {
+          line.remove(line.size()-1);
+        }
         if (line.size() > 0)
         {
           out.printf("\033*p%dX", sp.x + jump);


### PR DESCRIPTION
This can result in less data to send to the cutter and faster engraving.