### PR TITLE
Fix silly bug in file export method validation

### DIFF
--- a/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
+++ b/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
@@ -743,7 +743,7 @@ public class GenericGcodeDriver extends LaserCutter {
     }
     else if (UPLOAD_METHOD_FILE.equals(uploadMethod))
     {
-      if (getExportPath() != null && getExportPath().length() > 0)
+      if (getExportPath() == null || getExportPath().equals(""))
       {
         throw new IOException("Export Path must be set to upload via File method.");
       }


### PR DESCRIPTION
Got the sense wrong checking the contents of the export path config field.