### PR TITLE
Fix broken Smoothieboard serial and IP upload methods.

### DIFF
--- a/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
+++ b/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
@@ -245,7 +245,7 @@ public class GenericGcodeDriver extends LaserCutter {
     return exportPath;
   }
 
-  private String uploadMethod = "";
+  protected String uploadMethod = "";
 
   public void setUploadMethod(Object method)
   {

--- a/src/com/t_oster/liblasercut/drivers/SmoothieBoard.java
+++ b/src/com/t_oster/liblasercut/drivers/SmoothieBoard.java
@@ -47,13 +47,13 @@ public class SmoothieBoard extends GenericGcodeDriver {
   @Override
   public String getIdentificationLine()
   {
-    if (getHost() == null || "".equals(getHost()))
+    if (UPLOAD_METHOD_IP.equals(this.uploadMethod))
     {
-      return "Smoothie";
+      return "Smoothie command shell";
     }
     else
     {
-      return "Smoothie command shell";
+      return "Smoothie";
     }
   }
 
@@ -62,7 +62,7 @@ public class SmoothieBoard extends GenericGcodeDriver {
   {
     String line = super.waitForLine();
     //The telnet interface for smoothie prepends lines with '> '
-    if (getHost() != null && !"".equals(getHost()) && line.startsWith("> "))
+    if (UPLOAD_METHOD_IP.equals(this.uploadMethod) && line.startsWith("> "))
     {
       return line.substring(2);
     }


### PR DESCRIPTION
Missed a couple of instances of the smoothieboard driver looking at the host field to determine the upload method instead of the new uploadMethod setting.

Fixes https://github.com/t-oster/VisiCut/issues/359
