### PR TITLE
Add absolute speed option for Smoothieboard driver

### DIFF
--- a/src/com/t_oster/liblasercut/FloatPowerAbsSpeedFocusProperty.java
+++ b/src/com/t_oster/liblasercut/FloatPowerAbsSpeedFocusProperty.java
@@ -1,0 +1,89 @@
+/**
+ * This file is part of LibLaserCut.
+ * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+ *
+ * LibLaserCut is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LibLaserCut is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+package com.t_oster.liblasercut;
+
+public class FloatPowerAbsSpeedFocusProperty extends FloatPowerSpeedFocusProperty
+{
+  private float max_speed = 100;
+  
+  public FloatPowerAbsSpeedFocusProperty(float max_speed)
+  {
+    this.max_speed = max_speed;
+  }
+  
+  public void setSpeed(float speed)
+  {
+    speed = speed < 0 ? 0 : speed;
+    speed = speed > max_speed ? max_speed : speed;
+    this.speed = speed;
+  }
+
+  private static String[] propertyNames = new String[]{"power (%)", "speed (mm/min)", "focus (mm)"};
+
+  @Override
+  public String[] getPropertyKeys()
+  {
+    return propertyNames;
+  }
+
+  @Override
+  public FloatPowerAbsSpeedFocusProperty clone()
+  {
+    FloatPowerAbsSpeedFocusProperty p = new FloatPowerAbsSpeedFocusProperty(this.max_speed);
+    p.focus = focus;
+    p.power = power;
+    p.speed = speed;
+    return p;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null) {
+        return false;
+    }
+    if (getClass() != obj.getClass()) {
+        return false;
+    }
+    final FloatPowerAbsSpeedFocusProperty other = (FloatPowerAbsSpeedFocusProperty) obj;
+    if (Float.floatToIntBits(this.power) != Float.floatToIntBits(other.power)) {
+        return false;
+    }
+    if (Float.floatToIntBits(this.speed) != Float.floatToIntBits(other.speed)) {
+        return false;
+    }
+    if (Float.floatToIntBits(this.max_speed) != Float.floatToIntBits(other.max_speed)) {
+        return false;
+    }
+    if (Float.floatToIntBits(this.focus) != Float.floatToIntBits(other.focus)) {
+        return false;
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 7;
+    hash = 67 * hash + Float.floatToIntBits(this.power);
+    hash = 67 * hash + Float.floatToIntBits(this.speed);
+    hash = 67 * hash + Float.floatToIntBits(this.max_speed);
+    hash = 67 * hash + Float.floatToIntBits(this.focus);
+    return hash;
+  }
+
+}

--- a/src/com/t_oster/liblasercut/FloatPowerSpeedFocusProperty.java
+++ b/src/com/t_oster/liblasercut/FloatPowerSpeedFocusProperty.java
@@ -27,9 +27,9 @@ package com.t_oster.liblasercut;
 public class FloatPowerSpeedFocusProperty implements LaserProperty
 {
 
-  private float power = 20;
-  private float speed = 100;
-  private float focus = 0;
+  protected float power = 20;
+  protected float speed = 100;
+  protected float focus = 0;
 
   public FloatPowerSpeedFocusProperty()
   {
@@ -100,7 +100,7 @@ public class FloatPowerSpeedFocusProperty implements LaserProperty
     return p;
   }
 
-  private static String[] propertyNames = new String[]{"power", "speed", "focus"};
+  private static String[] propertyNames = new String[]{"power (%)", "speed (%)", "focus (mm)"};
   
   @Override
   public String[] getPropertyKeys()
@@ -111,15 +111,15 @@ public class FloatPowerSpeedFocusProperty implements LaserProperty
   @Override
   public Object getProperty(String name)
   {
-    if ("power".equals(name))
+    if (name.startsWith("power"))
     {
       return (Float) this.getPower();
     }
-    else if ("speed".equals(name))
+    else if (name.startsWith("speed"))
     {
       return (Float) this.getSpeed();
     }
-    else if ("focus".equals(name))
+    else if (name.startsWith("focus"))
     {
       return (Float) this.getFocus();
     }
@@ -129,15 +129,15 @@ public class FloatPowerSpeedFocusProperty implements LaserProperty
   @Override
   public void setProperty(String name, Object value)
   {
-    if ("power".equals(name))
+    if (name.startsWith("power"))
     {
       this.setPower((Float) value);
     }
-    else if ("speed".equals(name))
+    else if (name.startsWith("speed"))
     {
       this.setSpeed((Float) value);
     }
-    else if ("focus".equals(name))
+    else if (name.startsWith("focus"))
     {
       this.setFocus((Float) value);
     }
@@ -150,19 +150,15 @@ public class FloatPowerSpeedFocusProperty implements LaserProperty
   @Override
   public Object getMinimumValue(String name)
   {
-  if ("power".equals(name))
+    if (name.startsWith("power"))
     {
       return (Float) 0f;
     }
-    else if ("speed".equals(name))
+    else if (name.startsWith("speed"))
     {
       return (Float) 0f;
     }
-    else if ("focus".equals(name))
-    {
-      return null;
-    }
-    else if ("frequency".equals(name))
+    else if (name.startsWith("focus"))
     {
       return null;
     }
@@ -175,19 +171,15 @@ public class FloatPowerSpeedFocusProperty implements LaserProperty
   @Override
   public Object getMaximumValue(String name)
   {
-    if ("power".equals(name))
+    if (name.startsWith("power"))
     {
       return (Float) 100f;
     }
-    else if ("speed".equals(name))
+    else if (name.startsWith("speed"))
     {
       return (Float) 100f;
     }
-    else if ("focus".equals(name))
-    {
-      return null;
-    }
-    else if ("frequency".equals(name))
+    else if (name.startsWith("focus"))
     {
       return null;
     }
@@ -233,5 +225,4 @@ public class FloatPowerSpeedFocusProperty implements LaserProperty
         return hash;
     }
   
-
 }

--- a/src/com/t_oster/liblasercut/LibInfo.java
+++ b/src/com/t_oster/liblasercut/LibInfo.java
@@ -50,6 +50,7 @@ public class LibInfo
       GenericGcodeDriver.class,
       Grbl.class,
       SmoothieBoard.class,
+      SmoothieBoardAbsolute.class,
       Marlin.class
     };
   }

--- a/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
+++ b/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
@@ -443,11 +443,11 @@ public class GenericGcodeDriver extends LaserCutter {
   private double currentPower = -1;
   private double currentSpeed = -1;
   private double nextPower = -1;
-  private double nextSpeed = -1;
+  protected double nextSpeed = -1;
   private double currentFocus = 0;
 
   protected void setSpeed(double speedInPercent) {
-    nextSpeed = speedInPercent;
+    nextSpeed = max_speed*speedInPercent/100.0;
   }
 
   protected void setPower(double powerInPercent) {
@@ -469,11 +469,11 @@ public class GenericGcodeDriver extends LaserCutter {
     if (blankLaserDuringRapids)
     {
       currentPower = 0.0;
-      sendLine("G0 X%f Y%f F%d S0", x, y, (int) (travel_speed));
+      sendLine("G0 X%f Y%f F%f S0", x, y, currentSpeed);
     }
     else
     {
-      sendLine("G0 X%f Y%f F%d", x, y, (int) (travel_speed));
+      sendLine("G0 X%f Y%f F%f", x, y, currentSpeed);
     }
   }
 
@@ -488,7 +488,7 @@ public class GenericGcodeDriver extends LaserCutter {
     }
     if (nextSpeed != currentSpeed)
     {
-      append += String.format(FORMAT_LOCALE, " F%d", (int) (max_speed*nextSpeed/100.0));
+      append += String.format(FORMAT_LOCALE, " F%f", nextSpeed);
       currentSpeed = nextSpeed;
     }
     sendLine("G1 X%f Y%f"+append, x, y);

--- a/src/com/t_oster/liblasercut/drivers/SmoothieBoard.java
+++ b/src/com/t_oster/liblasercut/drivers/SmoothieBoard.java
@@ -87,7 +87,7 @@ public class SmoothieBoard extends GenericGcodeDriver {
   @Override
   public String getModelName()
   {
-    return "Smoothie Board";
+    return "Smoothieboard";
   }
 
   @Override
@@ -97,5 +97,4 @@ public class SmoothieBoard extends GenericGcodeDriver {
     clone.copyProperties(this);
     return clone;
   }
-
 }

--- a/src/com/t_oster/liblasercut/drivers/SmoothieBoardAbsolute.java
+++ b/src/com/t_oster/liblasercut/drivers/SmoothieBoardAbsolute.java
@@ -1,0 +1,63 @@
+/**
+ * This file is part of LibLaserCut.
+ * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+ *
+ * LibLaserCut is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LibLaserCut is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+package com.t_oster.liblasercut.drivers;
+
+import com.t_oster.liblasercut.FloatPowerAbsSpeedFocusProperty;
+import com.t_oster.liblasercut.LaserProperty;
+
+public class SmoothieBoardAbsolute extends SmoothieBoard
+{
+  @Override
+  public String getModelName()
+  {
+    return "Smoothieboard (absolute speeds)";
+  }
+
+  @Override
+  public LaserProperty getLaserPropertyForVectorPart() {
+    return new FloatPowerAbsSpeedFocusProperty((float) this.max_speed);
+  }
+
+  @Override
+  public LaserProperty getLaserPropertyForRaster3dPart()
+  {
+    return new FloatPowerAbsSpeedFocusProperty((float) this.max_speed);
+  }
+
+  @Override
+  public LaserProperty getLaserPropertyForRasterPart()
+  {
+    return new FloatPowerAbsSpeedFocusProperty((float) this.max_speed);
+  }
+
+  @Override
+  protected void setSpeed(double speed)
+  {
+    this.nextSpeed = speed;
+  }
+
+  @Override
+  public SmoothieBoardAbsolute clone()
+  {
+    SmoothieBoardAbsolute clone = new SmoothieBoardAbsolute();
+    clone.copyProperties(this);
+    return clone;
+  }
+
+}


### PR DESCRIPTION
Adds new Smoothie driver that changes the meaning of the Speed variable from percent to mm/min.

Needs more work, don't merge just yet.

https://github.com/t-oster/VisiCut/issues/381
