### PR TITLE
Grbl: don't send feed rate as part of a G0 rapid, don't send spaces

### DIFF
--- a/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
+++ b/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
@@ -523,7 +523,7 @@ public class GenericGcodeDriver extends LaserCutter {
 
   protected void sendLine(String text, Object... parameters) throws IOException
   {
-    out.format(FORMAT_LOCALE, text.replace(" ", "")+LINEEND(), parameters);
+    out.format(FORMAT_LOCALE, text+LINEEND(), parameters);
     //TODO: Remove
     System.out.println(String.format(FORMAT_LOCALE, "> "+text+LINEEND(), parameters));
     out.flush();

--- a/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
+++ b/src/com/t_oster/liblasercut/drivers/GenericGcodeDriver.java
@@ -440,8 +440,8 @@ public class GenericGcodeDriver extends LaserCutter {
       }
     }
   }
-  private double currentPower = -1;
-  private double currentSpeed = -1;
+  protected double currentPower = -1;
+  protected double currentSpeed = -1;
   private double nextPower = -1;
   private double nextSpeed = -1;
   private double currentFocus = 0;
@@ -523,7 +523,7 @@ public class GenericGcodeDriver extends LaserCutter {
 
   protected void sendLine(String text, Object... parameters) throws IOException
   {
-    out.format(FORMAT_LOCALE, text+LINEEND(), parameters);
+    out.format(FORMAT_LOCALE, text.replace(" ", "")+LINEEND(), parameters);
     //TODO: Remove
     System.out.println(String.format(FORMAT_LOCALE, "> "+text+LINEEND(), parameters));
     out.flush();

--- a/src/com/t_oster/liblasercut/drivers/Grbl.java
+++ b/src/com/t_oster/liblasercut/drivers/Grbl.java
@@ -160,6 +160,32 @@ public class Grbl extends GenericGcodeDriver
     
     return null;
   }
+  
+  /**
+   * Send a G0 rapid move to Grbl.
+   * Doesn't include travel speed since grbl ignores that anyway.
+   * 
+   * @param out
+   * @param x
+   * @param y
+   * @param resolution
+   * @throws IOException 
+   */
+  @Override
+  protected void move(PrintStream out, double x, double y, double resolution) throws IOException {
+    x = isFlipXaxis() ? getBedWidth() - Util.px2mm(x, resolution) : Util.px2mm(x, resolution);
+    y = isFlipYaxis() ? getBedHeight() - Util.px2mm(y, resolution) : Util.px2mm(y, resolution);
+    currentSpeed = getTravel_speed();
+    if (blankLaserDuringRapids)
+    {
+      currentPower = 0.0;
+      sendLine("G0 X%f Y%f S0", x, y);
+    }
+    else
+    {
+      sendLine("G0 X%f Y%f", x, y);
+    }
+  }
 
   @Override
   public Grbl clone()

--- a/src/com/t_oster/liblasercut/drivers/Grbl.java
+++ b/src/com/t_oster/liblasercut/drivers/Grbl.java
@@ -186,6 +186,29 @@ public class Grbl extends GenericGcodeDriver
       sendLine("G0 X%f Y%f", x, y);
     }
   }
+  
+  /**
+   * Send a line of gcode to the cutter, stripping out any whitespace in the process
+   * @param text
+   * @param parameters
+   * @throws IOException 
+   */
+  @Override
+  protected void sendLine(String text, Object... parameters) throws IOException
+  {
+    out.format(FORMAT_LOCALE, text.replace(" ", "")+LINEEND(), parameters);
+    //TODO: Remove
+    System.out.println(String.format(FORMAT_LOCALE, "> "+text+LINEEND(), parameters));
+    out.flush();
+    if (isWaitForOKafterEachLine())
+    {
+      String line = waitForLine();
+      if (!"ok".equals(line))
+      {
+        throw new IOException("Lasercutter did not respond 'ok', but '"+line+"'instead.");
+      }
+    }
+  }
 
   @Override
   public Grbl clone()


### PR DESCRIPTION
Couple of minor Grbl specific tweaks:
* Don't send feed rate as part of a G0 rapid  (#67)
* And don't send spaces in transmitted gcode since Grbl filters them out anyway