### PR TITLE
set default power to 0%

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: java
 jdk:
-  - oraclejdk7
   - openjdk7
-  - openjdk6
 
 
 script:

--- a/src/com/t_oster/liblasercut/PowerSpeedFocusProperty.java
+++ b/src/com/t_oster/liblasercut/PowerSpeedFocusProperty.java
@@ -30,7 +30,7 @@ import java.util.Collection;
 public class PowerSpeedFocusProperty implements LaserProperty
 {
 
-  private int power = 20;
+  private int power = 0;
   private int speed = 100;
   private float focus = 0;
 


### PR DESCRIPTION
Previous default was 20%, which had the confusing effect that if a material-thickness combination has no laser settings for a certain profile, VisiCut just quietly used 20% power as laser setting.

Depending on the lasercutter and material, 20% is already way too much, or it almost cuts through, so that you don't notice you ruined everything until the end of the job.

The new default prevents errors because simply nothing will be cut. (A warning would be better, but that's the job of the GUI and not of LibLaserCut).

Workaround for https://github.com/t-oster/VisiCut/issues/207