### PR TITLE
remove moveto 0,0 in epilog driver init sequence

### DIFF
--- a/src/com/t_oster/liblasercut/drivers/EpilogCutter.java
+++ b/src/com/t_oster/liblasercut/drivers/EpilogCutter.java
@@ -655,7 +655,7 @@ abstract class EpilogCutter extends LaserCutter
     ByteArrayOutputStream result = new ByteArrayOutputStream();
     PrintStream out = new PrintStream(result, true, "US-ASCII");
     out.printf("\033%%1B");// Start HLGL
-    out.printf("IN;PU0,0;");
+    out.printf("IN;");
     //Reset Focus to 0
     out.printf("WF%d;", 0);
     return result.toByteArray();
@@ -668,7 +668,7 @@ abstract class EpilogCutter extends LaserCutter
     PrintStream out = new PrintStream(result, true, "US-ASCII");
     /* Resolution of the print. Number of Units/Inch*/
     out.printf("\033%%1B");// Start HLGL
-    out.printf("IN;PU0,0;");
+    out.printf("IN;");
 
     if (vp != null)
     {


### PR DESCRIPTION
removing the moveto 0,0 in epilog driver init sequence allows the autofocus to happen at the first point of the cut (where presumably there is material) rather than the origin (where there might not be material), but shouldn't make a difference otherwise.
