### PR TITLE
Add support for hiding focus setting and switching autofocus off

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: java
 jdk:
-  - oraclejdk7
   - openjdk7
-  - openjdk6
 
 
 script:

--- a/src/com/t_oster/liblasercut/LaserJob.java
+++ b/src/com/t_oster/liblasercut/LaserJob.java
@@ -39,6 +39,7 @@ public class LaserJob
   private double startX = 0;
   private double startY = 0;
   private List<JobPart> parts = new LinkedList<JobPart>();
+  private boolean autoFocusEnabled = true;
 
   public LaserJob(String title, String name, String user)
   {
@@ -140,5 +141,18 @@ public class LaserJob
       startX = 0;
       startY = 0;
     }
+  }
+
+  /**
+   * Sets whether autofocus is enabled for this job.
+   * No-op for lasers that do not support it.
+   */
+  public void setAutoFocusEnabled(boolean b) {
+    autoFocusEnabled = b;
+  }
+
+  /** Indicates whether autofocus is enabled for this job, assuming the cutter supports it. */
+  public boolean isAutoFocusEnabled() {
+    return autoFocusEnabled;
   }
 }

--- a/src/com/t_oster/liblasercut/PowerSpeedFocusFrequencyProperty.java
+++ b/src/com/t_oster/liblasercut/PowerSpeedFocusFrequencyProperty.java
@@ -28,16 +28,15 @@ public class PowerSpeedFocusFrequencyProperty extends PowerSpeedFocusProperty
 {
 
   private int frequency = 5000;
-  private boolean useFocus = true;
 
   public PowerSpeedFocusFrequencyProperty()
   {
   }
 
   /** Make a new PowerSpeedFocusFrequencyProperty that optionally utilizes the focus setting */
-  public PowerSpeedFocusFrequencyProperty(boolean useFocus)
+  public PowerSpeedFocusFrequencyProperty(boolean hideFocus)
   {
-    this.useFocus = useFocus;
+    super(hideFocus);
   }
 
   public void setFrequency(int frequency)
@@ -58,10 +57,10 @@ public class PowerSpeedFocusFrequencyProperty extends PowerSpeedFocusProperty
   @Override
   public String[] getPropertyKeys()
   {
-    if (useFocus) {
-      return propertyNames;
-    } else {
+    if (isHideFocus()) {
       return propertyNamesNoFocus;
+    } else {
+      return propertyNames;
     }
   }
 
@@ -138,7 +137,7 @@ public class PowerSpeedFocusFrequencyProperty extends PowerSpeedFocusProperty
     p.setPower(getPower());
     p.setSpeed(getSpeed());
     p.setFocus(getFocus());
-    p.useFocus = useFocus;
+    p.setHideFocus(isHideFocus());
     return p;
   }
 

--- a/src/com/t_oster/liblasercut/PowerSpeedFocusFrequencyProperty.java
+++ b/src/com/t_oster/liblasercut/PowerSpeedFocusFrequencyProperty.java
@@ -28,9 +28,16 @@ public class PowerSpeedFocusFrequencyProperty extends PowerSpeedFocusProperty
 {
 
   private int frequency = 5000;
- 
+  private boolean useFocus = true;
+
   public PowerSpeedFocusFrequencyProperty()
   {
+  }
+
+  /** Make a new PowerSpeedFocusFrequencyProperty that optionally utilizes the focus setting */
+  public PowerSpeedFocusFrequencyProperty(boolean useFocus)
+  {
+    this.useFocus = useFocus;
   }
 
   public void setFrequency(int frequency)
@@ -46,13 +53,18 @@ public class PowerSpeedFocusFrequencyProperty extends PowerSpeedFocusProperty
   }
 
   private static String[] propertyNames = new String[]{"power", "speed", "focus", "frequency"};
-  
+  private static String[] propertyNamesNoFocus = new String[]{"power", "speed", "frequency"};
+
   @Override
   public String[] getPropertyKeys()
   {
-    return propertyNames;
+    if (useFocus) {
+      return propertyNames;
+    } else {
+      return propertyNamesNoFocus;
+    }
   }
-  
+
   @Override
   public Object getProperty(String name)
   {
@@ -104,7 +116,7 @@ public class PowerSpeedFocusFrequencyProperty extends PowerSpeedFocusProperty
        return super.getMaximumValue(name);
      }
   }
-  
+
   @Override
   public Object[] getPossibleValues(String name)
   {
@@ -117,7 +129,7 @@ public class PowerSpeedFocusFrequencyProperty extends PowerSpeedFocusProperty
       return super.getPossibleValues(name);
     }
   }
-  
+
   @Override
   public PowerSpeedFocusFrequencyProperty clone()
   {
@@ -126,6 +138,7 @@ public class PowerSpeedFocusFrequencyProperty extends PowerSpeedFocusProperty
     p.setPower(getPower());
     p.setSpeed(getSpeed());
     p.setFocus(getFocus());
+    p.useFocus = useFocus;
     return p;
   }
 

--- a/src/com/t_oster/liblasercut/PowerSpeedFocusProperty.java
+++ b/src/com/t_oster/liblasercut/PowerSpeedFocusProperty.java
@@ -30,7 +30,7 @@ import java.util.Collection;
 public class PowerSpeedFocusProperty implements LaserProperty
 {
 
-  private int power = 20;
+  private int power = 0;
   private int speed = 100;
   private float focus = 0;
 

--- a/src/com/t_oster/liblasercut/PowerSpeedFocusProperty.java
+++ b/src/com/t_oster/liblasercut/PowerSpeedFocusProperty.java
@@ -33,16 +33,16 @@ public class PowerSpeedFocusProperty implements LaserProperty
   private int power = 0;
   private int speed = 100;
   private float focus = 0;
-  private boolean useFocus = true;
+  private boolean hideFocus = false;
 
   public PowerSpeedFocusProperty()
   {
   }
 
   /** Make a new PowerSpeedFocusProperty that optionally utilizes the focus setting */
-  public PowerSpeedFocusProperty(boolean useFocus)
+  public PowerSpeedFocusProperty(boolean hideFocus)
   {
-      this.useFocus = useFocus;
+      this.hideFocus = hideFocus;
   }
 
   /**
@@ -100,6 +100,14 @@ public class PowerSpeedFocusProperty implements LaserProperty
     return this.focus;
   }
 
+  public void setHideFocus(boolean hf) {
+    hideFocus = hf;
+  }
+
+  public boolean isHideFocus() {
+    return hideFocus;
+  }
+
   @Override
   public PowerSpeedFocusProperty clone()
   {
@@ -107,7 +115,7 @@ public class PowerSpeedFocusProperty implements LaserProperty
     p.power = power;
     p.speed = speed;
     p.focus = focus;
-    p.useFocus = useFocus;
+    p.hideFocus = hideFocus;
     return p;
   }
 
@@ -117,10 +125,10 @@ public class PowerSpeedFocusProperty implements LaserProperty
   @Override
   public String[] getPropertyKeys()
   {
-    if (useFocus) {
-      return propertyNames;
-    } else {
+    if (hideFocus) {
       return propertyNamesNoFocus;
+    } else {
+      return propertyNames;
     }
   }
 

--- a/src/com/t_oster/liblasercut/PowerSpeedFocusProperty.java
+++ b/src/com/t_oster/liblasercut/PowerSpeedFocusProperty.java
@@ -33,9 +33,16 @@ public class PowerSpeedFocusProperty implements LaserProperty
   private int power = 0;
   private int speed = 100;
   private float focus = 0;
+  private boolean useFocus = true;
 
   public PowerSpeedFocusProperty()
   {
+  }
+
+  /** Make a new PowerSpeedFocusProperty that optionally utilizes the focus setting */
+  public PowerSpeedFocusProperty(boolean useFocus)
+  {
+      this.useFocus = useFocus;
   }
 
   /**
@@ -100,15 +107,21 @@ public class PowerSpeedFocusProperty implements LaserProperty
     p.power = power;
     p.speed = speed;
     p.focus = focus;
+    p.useFocus = useFocus;
     return p;
   }
 
   private static String[] propertyNames = new String[]{"power", "speed", "focus"};
+  private static String[] propertyNamesNoFocus = new String[]{"power", "speed"};
   
   @Override
   public String[] getPropertyKeys()
   {
-    return propertyNames;
+    if (useFocus) {
+      return propertyNames;
+    } else {
+      return propertyNamesNoFocus;
+    }
   }
 
   @Override

--- a/src/com/t_oster/liblasercut/drivers/EpilogCutter.java
+++ b/src/com/t_oster/liblasercut/drivers/EpilogCutter.java
@@ -53,8 +53,8 @@ abstract class EpilogCutter extends LaserCutter
   private String hostname = "10.0.0.1";
   private int port = 515;
   private boolean autofocus = false;
-  // Not all epilogs support focusing laser commands
-  private boolean softwareFocusSupported = true;
+  /** Not all epilogs support focusing laser commands.  Setting this true will hide it in the UI. */
+  private boolean hideSoftwareFocus = false;
   private transient InputStream in;
   private transient OutputStream out;
 
@@ -98,27 +98,27 @@ abstract class EpilogCutter extends LaserCutter
     this.autofocus = af;
   }
 
-  public boolean isSoftwareFocusSupported() {
-    return this.softwareFocusSupported;
+  public boolean isHideSoftwareFocus() {
+    return this.hideSoftwareFocus;
   }
 
-  public void setSoftwareFocusSupported(boolean sf) {
-    this.softwareFocusSupported = sf;
+  public void setHideSoftwareFocus(boolean sf) {
+    this.hideSoftwareFocus = sf;
   }
 
   @Override
   public LaserProperty getLaserPropertyForVectorPart() {
-    return new PowerSpeedFocusFrequencyProperty(isSoftwareFocusSupported());
+    return new PowerSpeedFocusFrequencyProperty(isHideSoftwareFocus());
   }
 
   @Override
   public LaserProperty getLaserPropertyForRasterPart() {
-    return new PowerSpeedFocusProperty(isSoftwareFocusSupported());
+    return new PowerSpeedFocusProperty(isHideSoftwareFocus());
   }
 
   @Override
   public LaserProperty getLaserPropertyForRaster3dPart() {
-    return new PowerSpeedFocusProperty(isSoftwareFocusSupported());
+    return new PowerSpeedFocusProperty(isHideSoftwareFocus());
   }
 
   private void waitForResponse(int expected) throws IOException, Exception
@@ -835,9 +835,9 @@ abstract class EpilogCutter extends LaserCutter
     {
       return (Double) this.getBedHeight();
     }
-    else if ("SoftwareFocusSupported".equals(attribute))
+    else if ("SoftwareFocusNotSupported".equals(attribute))
     {
-      return (Boolean) this.isSoftwareFocusSupported();
+      return (Boolean) this.isHideSoftwareFocus();
     }
     return null;
   }
@@ -909,14 +909,17 @@ abstract class EpilogCutter extends LaserCutter
     {
       this.setBedHeight((Double) value);
     }
-    else if ("SoftwareFocusSupported".equals(attribute))
+    else if ("SoftwareFocusNotSupported".equals(attribute))
     {
-      this.setSoftwareFocusSupported((Boolean) value);
+      this.setHideSoftwareFocus((Boolean) value);
     }
   }
   private static String[] attributes = new String[]
   {
-    "Hostname", "Port", "BedWidth", "BedHeight", "AutoFocus", "SoftwareFocusSupported"
+    // The slightly awkward wording of SoftwareFocusNotSupported is to handle importing old settings
+    // without disabling functionality.  Internally it is stored as hideSoftwareFocus, which removes
+    // it from the UI when software focus is not supported.
+    "Hostname", "Port", "BedWidth", "BedHeight", "AutoFocus", "SoftwareFocusNotSupported"
   };
 
   @Override

--- a/src/com/t_oster/liblasercut/drivers/EpilogCutter.java
+++ b/src/com/t_oster/liblasercut/drivers/EpilogCutter.java
@@ -655,7 +655,7 @@ abstract class EpilogCutter extends LaserCutter
     ByteArrayOutputStream result = new ByteArrayOutputStream();
     PrintStream out = new PrintStream(result, true, "US-ASCII");
     out.printf("\033%%1B");// Start HLGL
-    out.printf("IN;PU0,0;");
+    out.printf("IN;");
     //Reset Focus to 0
     out.printf("WF%d;", 0);
     return result.toByteArray();
@@ -668,7 +668,7 @@ abstract class EpilogCutter extends LaserCutter
     PrintStream out = new PrintStream(result, true, "US-ASCII");
     /* Resolution of the print. Number of Units/Inch*/
     out.printf("\033%%1B");// Start HLGL
-    out.printf("IN;PU0,0;");
+    out.printf("IN;");
 
     if (vp != null)
     {

--- a/src/com/t_oster/liblasercut/drivers/EpilogCutter.java
+++ b/src/com/t_oster/liblasercut/drivers/EpilogCutter.java
@@ -53,6 +53,8 @@ abstract class EpilogCutter extends LaserCutter
   private String hostname = "10.0.0.1";
   private int port = 515;
   private boolean autofocus = false;
+  // Not all epilogs support focusing laser commands
+  private boolean softwareFocusSupported = true;
   private transient InputStream in;
   private transient OutputStream out;
 
@@ -94,6 +96,29 @@ abstract class EpilogCutter extends LaserCutter
   public void setAutoFocus(boolean af)
   {
     this.autofocus = af;
+  }
+
+  public boolean isSoftwareFocusSupported() {
+    return this.softwareFocusSupported;
+  }
+
+  public void setSoftwareFocusSupported(boolean sf) {
+    this.softwareFocusSupported = sf;
+  }
+
+  @Override
+  public LaserProperty getLaserPropertyForVectorPart() {
+    return new PowerSpeedFocusFrequencyProperty(isSoftwareFocusSupported());
+  }
+
+  @Override
+  public LaserProperty getLaserPropertyForRasterPart() {
+    return new PowerSpeedFocusProperty(isSoftwareFocusSupported());
+  }
+
+  @Override
+  public LaserProperty getLaserPropertyForRaster3dPart() {
+    return new PowerSpeedFocusProperty(isSoftwareFocusSupported());
   }
 
   private void waitForResponse(int expected) throws IOException, Exception
@@ -140,7 +165,7 @@ abstract class EpilogCutter extends LaserCutter
     /* Print the printer job language header. */
     out.printf("\033%%-12345X@PJL JOB NAME=%s\r\n", job.getTitle());
     out.printf("\033E@PJL ENTER LANGUAGE=PCL\r\n");
-    if (this.isAutoFocus())
+    if (this.isAutoFocus() && job.isAutoFocusEnabled())
     {
       /* Set autofocus on. */
       out.printf("\033&y1A");
@@ -368,6 +393,7 @@ abstract class EpilogCutter extends LaserCutter
       number++;
       LaserJob j = new LaserJob((size > 1 ? "("+number+"/"+size+")" : "" )+job.getTitle(), job.getName(), job.getUser());
       j.setStartPoint(job.getStartX(), job.getStartY());
+      j.setAutoFocusEnabled(job.isAutoFocusEnabled());
       for (JobPart p:current)
       {
         j.addPart(p);
@@ -809,6 +835,10 @@ abstract class EpilogCutter extends LaserCutter
     {
       return (Double) this.getBedHeight();
     }
+    else if ("SoftwareFocusSupported".equals(attribute))
+    {
+      return (Boolean) this.isSoftwareFocusSupported();
+    }
     return null;
   }
   protected double bedWidth = 600;
@@ -879,10 +909,14 @@ abstract class EpilogCutter extends LaserCutter
     {
       this.setBedHeight((Double) value);
     }
+    else if ("SoftwareFocusSupported".equals(attribute))
+    {
+      this.setSoftwareFocusSupported((Boolean) value);
+    }
   }
   private static String[] attributes = new String[]
   {
-    "Hostname", "Port", "BedWidth", "BedHeight", "AutoFocus"
+    "Hostname", "Port", "BedWidth", "BedHeight", "AutoFocus", "SoftwareFocusSupported"
   };
 
   @Override

--- a/src/com/t_oster/liblasercut/drivers/EpilogHelix.java
+++ b/src/com/t_oster/liblasercut/drivers/EpilogHelix.java
@@ -75,7 +75,7 @@ public class EpilogHelix extends EpilogCutter
     result.setBedHeight(this.getBedHeight());
     result.setBedWidth(this.getBedWidth());
     result.setAutoFocus(this.isAutoFocus());
-    result.setSoftwareFocusSupported(this.isSoftwareFocusSupported());
+    result.setHideSoftwareFocus(this.isHideSoftwareFocus());
     return result;
   }
 
@@ -141,14 +141,14 @@ public class EpilogHelix extends EpilogCutter
   }
   
   @Override
-  public boolean isSoftwareFocusSupported()
+  public boolean isHideSoftwareFocus()
   {
-    return super.isSoftwareFocusSupported();
+    return super.isHideSoftwareFocus();
   }
 
   @Override
-  public void setSoftwareFocusSupported(boolean b)
+  public void setHideSoftwareFocus(boolean b)
   {
-    super.setSoftwareFocusSupported(b);
+    super.setHideSoftwareFocus(b);
   }
 }

--- a/src/com/t_oster/liblasercut/drivers/EpilogHelix.java
+++ b/src/com/t_oster/liblasercut/drivers/EpilogHelix.java
@@ -75,6 +75,7 @@ public class EpilogHelix extends EpilogCutter
     result.setBedHeight(this.getBedHeight());
     result.setBedWidth(this.getBedWidth());
     result.setAutoFocus(this.isAutoFocus());
+    result.setSoftwareFocusSupported(this.isSoftwareFocusSupported());
     return result;
   }
 
@@ -137,5 +138,17 @@ public class EpilogHelix extends EpilogCutter
   public void setPort(int p)
   {
     super.setPort(p);
+  }
+  
+  @Override
+  public boolean isSoftwareFocusSupported()
+  {
+    return super.isSoftwareFocusSupported();
+  }
+
+  @Override
+  public void setSoftwareFocusSupported(boolean b)
+  {
+    super.setSoftwareFocusSupported(b);
   }
 }

--- a/src/com/t_oster/liblasercut/drivers/EpilogZing.java
+++ b/src/com/t_oster/liblasercut/drivers/EpilogZing.java
@@ -75,7 +75,7 @@ public class EpilogZing extends EpilogCutter
     result.setBedHeight(this.getBedHeight());
     result.setBedWidth(this.getBedWidth());
     result.setAutoFocus(this.isAutoFocus());
-    result.setSoftwareFocusSupported(this.isSoftwareFocusSupported());
+    result.setHideSoftwareFocus(this.isHideSoftwareFocus());
     return result;
   }
 
@@ -141,14 +141,14 @@ public class EpilogZing extends EpilogCutter
   }
 
   @Override
-  public boolean isSoftwareFocusSupported()
+  public boolean isHideSoftwareFocus()
   {
-    return super.isSoftwareFocusSupported();
+    return super.isHideSoftwareFocus();
   }
 
   @Override
-  public void setSoftwareFocusSupported(boolean b)
+  public void setHideSoftwareFocus(boolean b)
   {
-    super.setSoftwareFocusSupported(b);
+    super.setHideSoftwareFocus(b);
   }
 }

--- a/src/com/t_oster/liblasercut/drivers/EpilogZing.java
+++ b/src/com/t_oster/liblasercut/drivers/EpilogZing.java
@@ -75,6 +75,7 @@ public class EpilogZing extends EpilogCutter
     result.setBedHeight(this.getBedHeight());
     result.setBedWidth(this.getBedWidth());
     result.setAutoFocus(this.isAutoFocus());
+    result.setSoftwareFocusSupported(this.isSoftwareFocusSupported());
     return result;
   }
 
@@ -137,5 +138,17 @@ public class EpilogZing extends EpilogCutter
   public void setPort(int p)
   {
     super.setPort(p);
+  }
+
+  @Override
+  public boolean isSoftwareFocusSupported()
+  {
+    return super.isSoftwareFocusSupported();
+  }
+
+  @Override
+  public void setSoftwareFocusSupported(boolean b)
+  {
+    super.setSoftwareFocusSupported(b);
   }
 }


### PR DESCRIPTION
Not all epilog lasers support focusing from software, and not all autofocus-enabled cutters want to use autofocus all the time. Add options to control these.