### PR TITLE
Prevent joining of elements at points where >= 3 elements meet.

### DIFF
--- a/src/com/t_oster/liblasercut/platform/Point.java
+++ b/src/com/t_oster/liblasercut/platform/Point.java
@@ -64,10 +64,10 @@ public class Point
 
   public int compareTo(Point o)
   {
-    if (x < o.x) return -1;
-    if (x > o.x) return 1;
     if (y < o.y) return -1;
     if (y > o.y) return 1;
+    if (x < o.x) return -1;
+    if (x > o.x) return 1;
     return 0;
   }
 }

--- a/test/com/t_oster/liblasercut/vectoroptimizers/InnerFirstVectorOptimizerTest.java
+++ b/test/com/t_oster/liblasercut/vectoroptimizers/InnerFirstVectorOptimizerTest.java
@@ -71,9 +71,9 @@ public class InnerFirstVectorOptimizerTest
     List<Element> sorted = new InnerFirstVectorOptimizer().sort(elements);
 
     assertEquals(3, sorted.size());
-    assertEquals(newElem(50, 2, 1, 2, 2, 1, 2, 1, 1, 2, 1), sorted.get(0));
-    assertEquals(newElem(50, 2, 4, 1, 4, 1, 3, 2, 3, 2, 4), sorted.get(1));
-    assertEquals(newElem(50, 3, 5, 0, 5, 0, 0, 3, 0, 3, 5), sorted.get(2));
+    assertEquals(newElem(50, 1, 2, 1, 1, 2, 1, 2, 2, 1, 2), sorted.get(0));
+    assertEquals(newElem(50, 2, 4, 2, 3, 1, 3, 1, 4, 2, 4), sorted.get(1));
+    assertEquals(newElem(50, 3, 5, 3, 0, 0, 0, 0, 5, 3, 5), sorted.get(2));
   }
 
   @Test
@@ -113,10 +113,10 @@ public class InnerFirstVectorOptimizerTest
     List<Element> sorted = new InnerFirstVectorOptimizer().sort(elements);
 
     assertEquals(4, sorted.size());
-    assertEquals(newElem(100, 2, 1, 2, 2), sorted.get(0));
-    assertEquals(newElem(50, 2, 2, 1, 2, 1, 1, 2, 1), sorted.get(1));
-    assertEquals(newElem(50, 2, 4, 1, 4, 1, 3, 2, 3, 2, 4), sorted.get(2));
-    assertEquals(newElem(50, 3, 5, 0, 5, 0, 0, 3, 0, 3, 5), sorted.get(3));
+    assertEquals(newElem(100, 2, 2, 2, 1), sorted.get(0));
+    assertEquals(newElem(50, 2, 1, 1, 1, 1, 2, 2, 2), sorted.get(1));
+    assertEquals(newElem(50, 2, 4, 2, 3, 1, 3, 1, 4, 2, 4), sorted.get(2));
+    assertEquals(newElem(50, 3, 5, 3, 0, 0, 0, 0, 5, 3, 5), sorted.get(3));
   }
 
   @Test
@@ -132,18 +132,21 @@ public class InnerFirstVectorOptimizerTest
     2 | *-*-*
       | | | |
     3 * *-*-*
-      | | | |
-    4 | *-*-*
+      | 
+    4 | 
       |
     5 *-----*
 
      */
-    elements.add(newElem(50, 0, 0, 3, 0));
-    elements.add(newElem(50, 3, 5, 0, 5, 0, 3, 0, 0));
 
-    for (int i = 1; i <= 3; i++)
+    // Both elements starting at 0, 0; without the invert step to check for
+    // matches at the start instead of just at the end, this would fail to join.
+    elements.add(newElem(50, 0, 0, 3, 0));
+    elements.add(newElem(50, 0, 0, 0, 3, 0, 5, 3, 5));
+
+    for (int i = 1; i <= 2; i++)
     {
-      for (int j = 1; j <= 4; j++)
+      for (int j = 1; j <= 3; j++)
       {
         elements.add(newElem(50, i, j, i + 1, j));
         elements.add(newElem(50, j, i, j, i + 1));
@@ -153,16 +156,18 @@ public class InnerFirstVectorOptimizerTest
     List<Element> sorted = new InnerFirstVectorOptimizer().sort(elements);
 
     // Grid partially combined.
-    assertEquals(7, sorted.size());
-    assertEquals(newElem(50, 3, 2, 4, 2), sorted.get(0));
-    assertEquals(newElem(50, 1, 2, 1, 3), sorted.get(1));
-    assertEquals(newElem(50, 3, 3, 4, 3, 4, 2, 4, 1, 3, 1), sorted.get(2));
-    assertEquals(newElem(50, 3, 3, 3, 4), sorted.get(3));
-    assertEquals(newElem(50, 3, 2, 3, 3, 2, 3, 2, 4), sorted.get(4));
-    assertEquals(newElem(50, 4, 3, 4, 4, 3, 4, 2, 4, 1, 4, 1, 3, 2, 3, 2, 2, 1, 2, 1, 1, 2, 1, 2, 2, 3, 2, 3, 1, 2, 1), sorted.get(5));
+    assertEquals(9, sorted.size());
+    assertEquals(newElem(50, 2, 2, 1, 2), sorted.get(0));
+    assertEquals(newElem(50, 2, 2, 2, 1), sorted.get(1));
+    assertEquals(newElem(50, 1, 2, 1, 1, 2, 1), sorted.get(2));
+    assertEquals(newElem(50, 3, 2, 2, 2), sorted.get(3));
+    assertEquals(newElem(50, 3, 2, 3, 1, 2, 1), sorted.get(4));
+    assertEquals(newElem(50, 2, 3, 2, 2), sorted.get(5));
+    assertEquals(newElem(50, 2, 3, 1, 3, 1, 2), sorted.get(6));
+    assertEquals(newElem(50, 3, 2, 3, 3, 2, 3), sorted.get(7));
 
     // Polyline combined.
-    assertEquals(newElem(50, 3, 5, 0, 5, 0, 3, 0, 0, 3, 0), sorted.get(6));
+    assertEquals(newElem(50, 3, 5, 0, 5, 0, 3, 0, 0, 3, 0), sorted.get(8));
   }
 
   private static Element newElem(int power, int x1, int y1, int... moves)

--- a/test/com/t_oster/liblasercut/vectoroptimizers/InnerFirstVectorOptimizerTest.java
+++ b/test/com/t_oster/liblasercut/vectoroptimizers/InnerFirstVectorOptimizerTest.java
@@ -20,7 +20,12 @@ package com.t_oster.liblasercut.vectoroptimizers;
 
 import com.t_oster.liblasercut.PowerSpeedFocusProperty;
 import com.t_oster.liblasercut.platform.Point;
+import com.t_oster.liblasercut.platform.Rectangle;
 import com.t_oster.liblasercut.vectoroptimizers.VectorOptimizer.Element;
+import java.io.PrintWriter;
+import java.io.FileWriter;
+import java.io.BufferedWriter;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import static org.junit.Assert.*;
@@ -138,7 +143,7 @@ public class InnerFirstVectorOptimizerTest
 
     for (int i = 1; i <= 3; i++)
     {
-      for (int j = 1; j<= 4; j++)
+      for (int j = 1; j <= 4; j++)
       {
         elements.add(newElem(50, i, j, i + 1, j));
         elements.add(newElem(50, j, i, j, i + 1));
@@ -178,5 +183,145 @@ public class InnerFirstVectorOptimizerTest
     ret.prop = prop;
 
     return ret;
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  //
+  // Everything below this comment is a bit of fun -- couple of "tests" which
+  // output shell scripts which when run, output animated GIFs showing the laser
+  // cut path for a couple of tricky laser cutting cases. These are cases where
+  // more than two elements meet at a point, where overzealous joining can lead
+  // to a cut happening within an already-totalled-enclosed area. Such cuts,
+  // which go against the spirit of the INNER_FIRST algorithm, are coloured red
+  // in the produced GIFs.
+  //
+  // Enable the script generation by uncommenting the @Test annotations. The
+  // scripts require ImageMagick to be installed.
+  // @Test
+  public void squareGrid() throws IOException
+  {
+    ArrayList<Element> elements = new ArrayList();
+    for (int i = 0; i <= 3; i++)
+    {
+      for (int j = 0; j <= 4; j++)
+      {
+        elements.add(newElem(50, 50 * i, 50 * j, 50 * (i + 1), 50 * j));
+        elements.add(newElem(50, 50 * j, 50 * i, 50 * j, 50 * (i + 1)));
+      }
+    }
+
+    List<Element> sorted = new InnerFirstVectorOptimizer().sort(elements);
+
+    drawAnimation("square", sorted);
+  }
+
+  // @Test
+  public void hexagonGrid() throws IOException
+  {
+    ArrayList<Element> elements = new ArrayList();
+    final int SX = 24;
+    final int SY = 15;
+    final int OX = SX * 3;
+    final int OY = 0;
+    final int S = 3;
+    for (int i = 0; i <= 5; i++)
+    {
+      for (int j = 0; j <= 5; j++)
+      {
+        if (Math.abs(i - j) < S)
+        {
+          elements.add(newElem(
+            50, OX + SX * (2 * i - j), OY + SY * (3 * j),
+            OX + SX * (2 * i - j - 1), OY + SY * (3 * j + 1)));
+        }
+        if (Math.abs(i - j + 0.5) < S + 0.3 && i < 5)
+        {
+          elements.add(newElem(
+            50, OX + SX * (2 * i - j), OY + SY * (3 * j),
+            OX + SX * (2 * i - j + 1), OY + SY * (3 * j + 1)));
+        }
+        if (Math.abs(i - j - 0.5) < S + 0.3 && j < 5)
+        {
+          elements.add(newElem(
+            50, OX + SX * (2 * i - j - 1), OY + SY * (3 * j + 1),
+            OX + SX * (2 * i - j - 1), OY + SY * (3 * j + 3)));
+        }
+      }
+    }
+
+    List<Element> sorted = new InnerFirstVectorOptimizer().sort(elements);
+
+    drawAnimation("hexagon", sorted);
+  }
+
+  private static final int BORDER = 5;
+  private static final int ANTIALIAS = 3;
+
+  private static void drawAnimation(String name, List<Element> sorted)
+    throws IOException
+  {
+    Rectangle bb = new Rectangle(
+      sorted.get(0).start.x, sorted.get(0).start.y,
+      sorted.get(0).start.x, sorted.get(0).start.y);
+    for (Element polyline : sorted)
+    {
+      bb.add(polyline.start);
+      for (Point p : polyline.moves)
+      {
+        bb.add(p);
+      }
+    }
+    String dimensions = ANTIALIAS * (bb.getXMax() + 2 * BORDER + 1) + "x"
+      + ANTIALIAS * (bb.getYMax() + 2 * BORDER + 1);
+    String finalDimensions = (bb.getXMax() + 2 * BORDER + 1) + "x"
+      + (bb.getYMax() + 2 * BORDER + 1);
+
+    PrintWriter out = new PrintWriter(
+      new BufferedWriter(new FileWriter(name + "_animation_gen.sh")));
+
+    out.printf("rm -f frame*.png\n");
+
+    final String CMD = "convert -size " + dimensions + " xc:Yellow +antialias "
+      + "-fill none -stroke Magenta -strokewidth " + ANTIALIAS + " -draw \"%s\""
+      + " -fill White -draw \"color -0,0 floodfill\" %s frame%05d.png\n";
+    final int F = 3;
+    int c = 0;
+    String drawCmd = "";
+    String compositeCommand = "";
+    for (Element polyline : sorted)
+    {
+      Point prev = polyline.start;
+      for (Point p : polyline.moves)
+      {
+        Point end = null;
+        for (int f = 1; f <= F; f++)
+        {
+          end = new Point(
+            (prev.x * (F - f) + p.x * f) / F, (prev.y * (F - f) + p.y * f) / F);
+          out.printf(
+            CMD, drawCmd + "line" + p2s(prev) + p2s(end), compositeCommand, c);
+          compositeCommand = String.format(
+            "frame%05d.png -compose Darken -composite", c);
+          ++c;
+        }
+        drawCmd += "line" + p2s(prev) + p2s(p) + " ";
+        prev = p;
+      }
+    }
+
+    --c;
+
+    out.printf("time convert -delay 6 -loop 0 frame*.png -delay 400 "
+      + "frame%05d.png -fill Black -opaque Magenta -fill wheat -opaque Yellow "
+      + "-resize %s %s.gif\n", c, finalDimensions, name);
+    out.printf("rm -f frame*.png\n");
+    out.close();
+  }
+
+  private static String p2s(Point p)
+  {
+    final int O = 5;
+    return " " + (ANTIALIAS * (p.x + BORDER) + ANTIALIAS / 2)
+      + "," + (ANTIALIAS * (p.y + BORDER) + ANTIALIAS / 2);
   }
 }


### PR DESCRIPTION
#84 works well for the simple, common cases that it was designed for, but is overly aggressive/non-deterministic when it comes to designs where >= 3 elements meet at a point:

![Hexagon Before](https://raw.githubusercontent.com/rbowmaker/LibLaserCut/gifs/badhexagon.gif) &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ![Square Before](https://raw.githubusercontent.com/rbowmaker/LibLaserCut/gifs/badsquare.gif)

The color red denotes cuts made on material that has already been cut out, i.e., failures to perform an "inside-out" cut. This pull request disables joining at points where >= 3 elements meet, returning to the previous segment-by-segment sorting in these cases:

![Hexagon After](https://raw.githubusercontent.com/rbowmaker/LibLaserCut/gifs/goodhexagon.gif) &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ![Square After](https://raw.githubusercontent.com/rbowmaker/LibLaserCut/gifs/goodsquare.gif)

Performance was tested using the same 20x20 grid of 31-gons as #84, and any change in speed was too small to be measurable compared to the noise.

This change includes (under Test Packages, so it shouldn't contribute to VisiCut's size) the code used to generate the animated GIFs above, it might be handy for other people to demonstrate future improvements?  I realise this is maybe a bit too off-topic to include so please feel free to remove it or ask me to do so, I'm happy to leave it my fork. 

Related: #83 