### PR TITLE
Changed or to and in the last x y check

### DIFF
--- a/src/com/t_oster/liblasercut/utils/ShapeConverter.java
+++ b/src/com/t_oster/liblasercut/utils/ShapeConverter.java
@@ -66,7 +66,7 @@ public class ShapeConverter
         //skip lines with length 0 https://github.com/t-oster/LibLaserCut/issues/87
         int x = (int) test[0];
         int y = (int) test[1];
-        if (x != lastx || y != lasty) {
+        if (x != lastx && y != lasty) {
           vectorpart.lineto(x, y);
           lastx = x;
           lasty = y;


### PR DESCRIPTION
If both the x and y coordinates are identical to the previous move skip them instead of that either just X or Y is on the same axis as the last move.