### PR TITLE
Add bottom-up engraving support (Epilog, currently)

### DIFF
--- a/src/com/t_oster/liblasercut/Raster3dPart.java
+++ b/src/com/t_oster/liblasercut/Raster3dPart.java
@@ -45,6 +45,14 @@ public class Raster3dPart extends RasterizableJobPart
   public int getBitsPerRasterPixel() {
     return 8;
   }
+  
+   public void setBottomUp(boolean bottomUp) {
+    this.cutBottomUp = bottomUp;
+  }
+
+  public boolean getBottomUp() {
+    return this.cutBottomUp;
+  }
 
   /**
    * Sets one line of the given rasterpart in the given result list.

--- a/src/com/t_oster/liblasercut/RasterPart.java
+++ b/src/com/t_oster/liblasercut/RasterPart.java
@@ -51,7 +51,14 @@ public class RasterPart extends RasterizableJobPart
   public int getBitsPerRasterPixel() {
     return 1;
   }
+  
+  public void setBottomUp(boolean bottomUp) {
+    this.cutBottomUp = bottomUp;
+  }
 
+  public boolean getBottomUp() {
+    return this.cutBottomUp;
+  }
   /**
    * Sets one line of the given rasterpart into the given result list.
    * every byte represents 8 pixel and the value corresponds to

--- a/src/com/t_oster/liblasercut/RasterizableJobPart.java
+++ b/src/com/t_oster/liblasercut/RasterizableJobPart.java
@@ -31,6 +31,7 @@ abstract public class RasterizableJobPart extends JobPart
   protected Point start = null;
   protected boolean cutDirectionleftToRight = true;
   protected double resolution = Double.NaN;
+  protected boolean cutBottomUp = false;
 
   @Override
   public double getDPI()

--- a/src/com/t_oster/liblasercut/drivers/EpilogCutter.java
+++ b/src/com/t_oster/liblasercut/drivers/EpilogCutter.java
@@ -483,9 +483,18 @@ abstract class EpilogCutter extends LaserCutter
       boolean leftToRight = true;
       ByteArrayList line = new ByteArrayList(rp.getRasterWidth());
       ByteArrayList encoded = new ByteArrayList(rp.getRasterWidth());
-      for (int y = 0; y < rp.getRasterHeight(); y++)
+      int y = 0;
+      if (rp.getBottomUp()) {
+        y = rp.getRasterHeight()-1;
+      }
+      for (;;)
       {
-	rp.getInvertedRasterLine(y, line);
+        if (rp.getBottomUp()) {
+          if (--y < 0) break;
+        } else {
+          if (++y >= rp.getRasterHeight()) break;
+        }
+         rp.getInvertedRasterLine(y, line);
         for (int n = 0; n < line.size(); n++)
         {//Apperantly the other power settings are ignored, so we have to scale
           int x = line.get(n);
@@ -607,7 +616,7 @@ abstract class EpilogCutter extends LaserCutter
      */
     out.printf("\033*b2M");
     /* Raster direction (1 = up, 0=down) */
-    out.printf("\033&y%dO", 0);
+    out.printf("\033&y%dO", rp.getBottomUp()?1:0);
     /* start at current position */
     out.printf("\033*r1A");
 
@@ -617,8 +626,17 @@ abstract class EpilogCutter extends LaserCutter
       boolean leftToRight = true;
       ByteArrayList line = new ByteArrayList(rp.getRasterWidth());
       ByteArrayList encoded = new ByteArrayList(rp.getRasterWidth());
-      for (int y = 0; y < rp.getRasterHeight(); y++)
+      int y = 0;
+      if (rp.getBottomUp()) {
+        y = rp.getRasterHeight()-1;
+      }
+      for (;;)
       {
+        if (rp.getBottomUp()) {
+          if (--y < 0) break;
+        } else {
+          if (++y >= rp.getRasterHeight()) break;
+        }
         rp.getRasterLine(y, line);
         //Remove leading zeroes, but keep track of the offset
         int jump = 0;


### PR DESCRIPTION
Bottom-up engraving allows engraving from the bottom of the job, which (for Epilogs) avoids having the extraction fan draw debris over the engraved portion.

Epilog's documentation: http://support.epiloglaser.com/article/8205/29949/using-the-bottomup-engraving-option-in-the-laser-dashboard

There's a partner PR coming for Visicut itself.