### PR TITLE
LaserScript: add prompt() function for user input

### DIFF
--- a/src/com/t_oster/liblasercut/laserscript/LaserScriptBootstrap.js
+++ b/src/com/t_oster/liblasercut/laserscript/LaserScriptBootstrap.js
@@ -41,3 +41,18 @@ function echo(text)
 {
   _instance.echo(text);
 }
+
+function prompt(title, defaultValue)
+{
+  return _instance.prompt(title, defaultValue);
+}
+
+function promptFloat(title, defaultValue)
+{
+  var result = parseFloat(_instance.prompt(title, defaultValue.toString()));
+  if (isNaN(result)) {
+    return defaultValue;
+  } else {
+    return result;
+  }
+}

--- a/src/com/t_oster/liblasercut/laserscript/ScriptInterface.java
+++ b/src/com/t_oster/liblasercut/laserscript/ScriptInterface.java
@@ -34,4 +34,6 @@ public interface ScriptInterface
   public Object get(String property);
   
   public void echo(String text);
+
+  public String prompt(String title, String defaultValue);
 }

--- a/src/com/t_oster/liblasercut/laserscript/VectorPartScriptInterface.java
+++ b/src/com/t_oster/liblasercut/laserscript/VectorPartScriptInterface.java
@@ -84,5 +84,12 @@ public class VectorPartScriptInterface implements ScriptInterface
   {
     System.err.println("LaserScript: "+text);
   }
+
+  @Override
+  public String prompt(String title, String defaultValue)
+  {
+    throw new UnsupportedOperationException("prompt() is not yet supported in commandline mode.");
+  }
+
   
 }

--- a/test/com/t_oster/liblasercut/laserscript/ScriptInterpreterTest.java
+++ b/test/com/t_oster/liblasercut/laserscript/ScriptInterpreterTest.java
@@ -79,6 +79,12 @@ public class ScriptInterpreterTest
         public void echo(String text)
         {
         }
+
+        @Override
+        public String prompt(String title, String defaultValue)
+        {
+          return null;
+        }
       });
     }
     catch (ScriptException e)
@@ -156,6 +162,13 @@ public class ScriptInterpreterTest
       public void echo(String text)
       {
         steps.add("echo ("+text+")");
+      }
+
+      @Override
+      public String prompt(String title, String defaultValue)
+      {
+        steps.add("prompt(" + title + "','" + defaultValue + "')");
+        return null;
       }
     });
     assertEquals(10, steps.size());


### PR DESCRIPTION
For now, this function is only a placeholder which is overridden by the VisiCut GUI. (pull request to be submitted soon)
If someone needs it, it could also be extended to support commandline (stdin) input.

Tested on Linux with the corresponding VisiCut pullrequest.