### PR TITLE
Several Tweaks, K40 NanoDriver running with RasterBuilder.

### DIFF
--- a/src/com/t_oster/liblasercut/RasterBuilder.java
+++ b/src/com/t_oster/liblasercut/RasterBuilder.java
@@ -490,6 +490,7 @@ public class RasterBuilder implements Iterable<VectorCommand>, Iterator<VectorCo
   {
     getUpdatedPixelAtLocation();
     x_position = nextColorChangeHeadingLeft(x_position, y_position, end);
+    x_position = Math.max(x_position,end);
     commitPosition();
 
     if (end < x_position)
@@ -506,6 +507,7 @@ public class RasterBuilder implements Iterable<VectorCommand>, Iterator<VectorCo
   {
     getUpdatedPixelAtLocation();
     y_position = nextColorChangeHeadingTop(x_position, y_position, end);
+    y_position = Math.max(y_position,end);
     commitPosition();
 
     if (end < y_position)
@@ -522,6 +524,7 @@ public class RasterBuilder implements Iterable<VectorCommand>, Iterator<VectorCo
   {
     getUpdatedPixelAtLocation();
     x_position = nextColorChangeHeadingRight(x_position, y_position, end);
+    x_position = Math.min(x_position,end);
     commitPosition();
 
     if (x_position < end)
@@ -538,6 +541,7 @@ public class RasterBuilder implements Iterable<VectorCommand>, Iterator<VectorCo
   {
     getUpdatedPixelAtLocation();
     y_position = nextColorChangeHeadingBottom(x_position, y_position, end);
+    y_position = Math.min(y_position,end);
     commitPosition();
 
     if (y_position < end)
@@ -643,7 +647,6 @@ public class RasterBuilder implements Iterable<VectorCommand>, Iterator<VectorCo
    */
   public int nextColorChangeHeadingLeft(int x, int y, int def)
   {
-    
     if (x <= -1) return def;
     if (x == 0) return -1;
     if (x == image.getWidth()) return image.getWidth()-1;

--- a/src/com/t_oster/liblasercut/RasterizableJobPart.java
+++ b/src/com/t_oster/liblasercut/RasterizableJobPart.java
@@ -37,6 +37,11 @@ abstract public class RasterizableJobPart extends JobPart
   {
       return resolution;
   }
+
+  public GreyscaleRaster getImage()
+  {
+    return image;
+  }
   
   /**
    * The initial laser settings to start a rasterization job with.

--- a/src/com/t_oster/liblasercut/drivers/K40NanoDriver.java
+++ b/src/com/t_oster/liblasercut/drivers/K40NanoDriver.java
@@ -18,12 +18,16 @@
  **/
 package com.t_oster.liblasercut.drivers;
 
+import com.t_oster.liblasercut.AbstractLaserProperty;
+import com.t_oster.liblasercut.BlackWhiteRaster;
 import com.t_oster.liblasercut.IllegalJobException;
 import com.t_oster.liblasercut.JobPart;
 import com.t_oster.liblasercut.LaserCutter;
 import com.t_oster.liblasercut.LaserJob;
 import com.t_oster.liblasercut.LaserProperty;
 import com.t_oster.liblasercut.ProgressListener;
+import com.t_oster.liblasercut.RasterBuilder;
+import com.t_oster.liblasercut.RasterElement;
 import com.t_oster.liblasercut.RasterPart;
 import com.t_oster.liblasercut.VectorCommand;
 import com.t_oster.liblasercut.VectorPart;
@@ -66,6 +70,8 @@ public class K40NanoDriver extends LaserCutter
   String board = "M2";
   boolean mock = false;
   PrintStream saveJob = null;
+  List<String> warnings = null;
+  ProgressListener progress = null;
 
   /**
    * This is the core method of the driver. It is called, whenever LibLaseCut
@@ -85,12 +91,15 @@ public class K40NanoDriver extends LaserCutter
   @Override
   public void sendJob(LaserJob job, ProgressListener pl, List<String> warnings) throws IllegalJobException, Exception
   {
+    this.progress = pl;
+    this.warnings = warnings;
     //let's check the job for some errors
     checkJob(job);
 
     K40Device device = new K40Device();
 
     device.setBoard(board);
+    this.progress.taskChanged(this, "Opening Device.");
     if (saveJob == null)
     {
       device.open();
@@ -128,94 +137,82 @@ public class K40NanoDriver extends LaserCutter
       {
         RasterPart rp = (RasterPart) p;
         LaserProperty property = rp.getLaserProperty();
-        K40NanoRasterProperty nrp = (K40NanoRasterProperty) property;
-        double speed = (Float) nrp.getProperty(K40NanoRasterProperty.VAR_MM_PER_SECOND);
+        double speed = (Float) property.getProperty("mm per second");
+
         device.setSpeed(speed);
         int sx = (int) (rp.getMinX() * (1000 / p.getDPI()));
         int sy = (int) (rp.getMinY() * (1000 / p.getDPI()));
         device.move_absolute(sx, sy);
-        
         int step_size = (int) (1000.0 / p.getDPI());
         device.setRaster_step(step_size);
-        
-        device.raster_start();
-        
-        int pixel_step_x = 1;
-        for (int y = 0, ye = rp.getRasterHeight(); y < ye; y++)
+        RasterElement element = ((BlackWhiteRaster)rp.getImage()).getRaster();
+        RasterBuilder rasterbuild = new RasterBuilder(element, new RasterBuilder.PropertiesUpdate()
         {
-          device.laser_off();
-          if (rp.lineIsBlank(y))
+          @Override
+          public void update(AbstractLaserProperty properties, int pixel)
           {
-            device.move_y(device.raster_step); //I can just skip blank lines.
-            continue;
+            properties.setProperty("pixel", pixel);
           }
-          int sequence = 0;
-          int x;
-          int xe;
-          if (pixel_step_x > 0)
+        }, 0, 0, 0);
+        rasterbuild.setOffsetPosition(rp.getMinX(), rp.getMinY());
+        
+        int pixel = 0;
+        device.raster_start();  
+        for (VectorCommand cmd : rasterbuild)
+        {
+          if ((cmd.getType() == VectorCommand.CmdType.MOVETO) || ((cmd.getType() == VectorCommand.CmdType.LINETO) && (pixel == 0))) //treat moveto with pixel 0 as a lineto.
           {
-            x = -1;
-            xe = rp.getRasterWidth() - 1;
+            int x = (int) (cmd.getX() * (1000 / p.getDPI()));
+            int y = (int) (cmd.getY() * (1000 / p.getDPI()));
+            int dx = x - device.x;
+            int dy = y - device.y;
+            if (dy > device.raster_step) {
+              device.move_absolute(x, y-device.raster_step);
+              //if we're moving in the y direction, but more than the raster step,
+              //we still need to h_switch to change the directionality. But, that will
+              //step, so we go down to where the raster-step will put us on the correct line.
+            }
+            if (dy == device.raster_step)
+            {
+              device.h_switch();
+              device.y += device.raster_step;
+            }
+            
+            device.move_absolute(x, y);
+            device.execute();
           }
           else
           {
-            x = rp.getRasterWidth();
-            xe = 0;
-          }
-          while (x != xe)
-          {
-            x += pixel_step_x;
-            if (rp.isBlack(x, y))
+            switch (cmd.getType())
             {
-              if (device.is_on) //already cutting.
+              case LINETO:
               {
-                sequence += pixel_step_x;
+                int x = (int) (cmd.getX() * (1000 / p.getDPI()));
+                int y = (int) (cmd.getY() * (1000 / p.getDPI()));
+                //Native units are mils.
+                device.cut_absolute(x, y);
+                device.execute();
+                break;
               }
-              else
-              { //not cutting, but should be.
-                if (sequence != 0)
-                {
-                  device.move_x(sequence * step_size);
-                }
-                device.laser_on();
-                sequence = pixel_step_x;
-              }
-            }
-            else
-            {
-              if (!device.is_on) //already not-cutting
+              case SETPROPERTY:
               {
-                sequence += pixel_step_x;
-              }
-              else
-              { //cutting, but shouldn't be.
-                if (sequence != 0)
-                {
-                  device.move_x(sequence * step_size);
-                }
-                device.laser_off();
-                sequence = pixel_step_x;
+                AbstractLaserProperty prop = (AbstractLaserProperty) cmd.getProperty();
+                pixel = prop.getInteger("pixel", pixel);
+                break;
               }
             }
           }
-          if (sequence != 0)
-          {
-            device.move_x(sequence * step_size); //whatever's left.
-          }
-          sequence = 0;
-          device.h_switch(); //explicitly flip directions with no magnatude. 
-          device.y += device.raster_step; //device triggered a raster step and changed y.
-          device.is_on = false; //device turned off no matter what, update that state.
-          pixel_step_x = -pixel_step_x; //stepping in the other direction.
         }
-        device.raster_end();
-        device.move_absolute(sx, sy);
       }
       else if (p instanceof VectorPart)
       {
         VectorPart vp = (VectorPart) p;
+        int i = 0;
+        int total = vp.getCommandList().length;
         for (VectorCommand cmd : vp.getCommandList())
         {
+          this.progress.taskChanged(this, "Vector Part");  
+          this.progress.progressChanged(this, (100 * i++) / total);
           switch (cmd.getType())
           {
             case LINETO:
@@ -272,7 +269,6 @@ public class K40NanoDriver extends LaserCutter
         }
       }
     }
-
     device.home(); //Home the device after the job.
     device.execute();
     device.close();
@@ -766,7 +762,6 @@ public class K40NanoDriver extends LaserCutter
     void execute()
     {
       queue.execute();
-
     }
 
     void encode_default_move(int dx, int dy)
@@ -1429,11 +1424,13 @@ public class K40NanoDriver extends LaserCutter
     private int interface_number = 0;
 
     public static final int STATUS_OK = 206;
-    public static final int STATUS_CRC = 207;
+    public static final int STATUS_PACKET_REJECTED = 207;
 
     public static final int STATUS_FINISH = 236;
     public static final int STATUS_BUSY = 238;
     public static final int STATUS_POWER = 239;
+
+    public static final int STATUS_DEVICE_ERROR = -1;
 
     public int byte_0 = 0;
     public int status = 0;
@@ -1441,6 +1438,8 @@ public class K40NanoDriver extends LaserCutter
     public int byte_3 = 0;
     public int byte_4 = 0;
     public int byte_5 = 0;
+
+    public int recovery = 0;
 
     /**
      * ******************
@@ -1493,6 +1492,13 @@ public class K40NanoDriver extends LaserCutter
       closeContext();
     }
 
+    public void error(String error)
+    {
+      //error message to be sent to GUI.
+      warnings.add(error);
+      System.out.println(error);
+    }
+
     @Override
     public void send_packet(CharSequence cs)
     {
@@ -1501,17 +1507,23 @@ public class K40NanoDriver extends LaserCutter
         throw new LibUsbException("Packets must be exactly " + PAYLOAD_LENGTH + " bytes.", 0);
       }
       create_packet(cs);
+      int count = 0;
       do
       {
         transmit_packet();
         update_status();
+        if (count >= 50)
+        {
+          throw new LibUsbException("All packets are being rejected.", 0);
+        }
+        count++;
       }
-      while (status == STATUS_CRC);
+      while (status == STATUS_PACKET_REJECTED);
     }
 
     private void create_packet(CharSequence cs)
     {
-      ((Buffer)packet).clear(); // Explicit cast for cross compatibility with JDK9
+      ((Buffer) packet).clear(); // Explicit cast for cross compatibility with JDK9
       packet.put((byte) 166);
       packet.put((byte) 0);
       for (int i = 0; i < cs.length(); i++)
@@ -1525,12 +1537,106 @@ public class K40NanoDriver extends LaserCutter
 
     private void transmit_packet()
     {
-      ((Buffer)transfered).clear(); // Explicit cast for cross compatibility with JDK9
+      ((Buffer) transfered).clear(); // Explicit cast for cross compatibility with JDK9
       int results = LibUsb.bulkTransfer(handle, K40_ENDPOINT_WRITE, packet, transfered, 5000L);
       if (results < LibUsb.SUCCESS)
       {
         throw new LibUsbException("Packet Send Failed.", results);
       }
+    }
+
+    private boolean waitForStatus()
+    {
+      recovery += 1;
+      Thread waitForStatusThread = new Thread()
+      {
+        int count = 0;
+
+        @Override
+        public void run()
+        {
+          if (progress != null)
+          {
+            progress.taskChanged(this, "Waiting for USB");
+          }
+          int results = -1;
+          synchronized (this)
+          {
+            while (results != LibUsb.SUCCESS)
+            {
+              try
+              {
+                Thread.sleep(2000);
+              }
+              catch (InterruptedException ex)
+              {
+              }
+              ((Buffer)transfered).clear(); // Explicit cast for cross compatibility with JDK9
+              request_status.put(0, (byte) 160);
+              if (handle == null)
+              {
+                //If device not found and restart fails there might no longer be a handle.
+                //If this is the case, our state is ERROR_NO_DEVICE.
+                results = LibUsb.ERROR_NO_DEVICE;
+              }
+              else
+              {
+                results = LibUsb.bulkTransfer(handle, K40_ENDPOINT_WRITE, request_status, transfered, 5000L);
+              }
+              switch (results)
+              {
+                case LibUsb.ERROR_NO_DEVICE:
+                  error("Device was not found. Attempting restart.");
+                  try
+                  {
+                    close();
+                    open();
+                  }
+                  catch (LibUsbException e)
+                  {
+                    error("Restart failed because: " + e.getLocalizedMessage());
+                  }
+                  break;
+                case LibUsb.ERROR_PIPE:
+                  error("USB pipe failed.");
+                  break;
+                case LibUsb.ERROR_TIMEOUT:
+                  error("USB timedout.");
+                  break;
+                case LibUsb.SUCCESS:
+                  notify();
+                  progress.taskChanged(this, "Sending Job");
+
+                  return;// Okay, we're back on track.
+                }
+              count++;
+              if (count >= 15)
+              {
+                throw new LibUsbException("Failed to recover from USB errors.", LibUsb.ERROR_TIMEOUT);
+              }
+              if (progress != null)
+              {
+                progress.progressChanged(this, (100 * count) / 15);
+              }
+            }
+          }
+        }
+      };
+      waitForStatusThread.start();
+      synchronized (waitForStatusThread)
+      {
+        try
+        {
+          error("A problem getting status was detected. We will wait for the device.");
+          waitForStatusThread.wait();
+        }
+        catch (Exception e)
+        {
+          return false;
+        }
+      }
+      //Status must have been successful.
+      return true;
     }
 
     private void update_status()
@@ -1544,15 +1650,21 @@ public class K40NanoDriver extends LaserCutter
 
       if (results < LibUsb.SUCCESS)
       {
-        throw new LibUsbException("Status Request Failed.", results);
-
+        boolean recoverable = waitForStatus(); //put in holding pattern.
+        if (!recoverable)
+        {
+          throw new LibUsbException("Status Request Failed.", results);
+        }
       }
-
+      if (handle == null) throw new LibUsbException("Status Request Failed.", results);
       ByteBuffer read_buffer = ByteBuffer.allocateDirect(6);
       results = LibUsb.bulkTransfer(handle, K40_ENDPOINT_READ, read_buffer, transfered, 5000L);
       if (results < LibUsb.SUCCESS)
       {
-        throw new LibUsbException("Status Update Failed", results);
+        //If the read failed, after successfully sending request, we say status is error.
+        status = STATUS_DEVICE_ERROR;
+        error("Status read failed. After 160 sent.");
+        return;
       }
 
       if (transfered.get(0) == 6)
@@ -1567,7 +1679,7 @@ public class K40NanoDriver extends LaserCutter
         /*
         //Other than byte 1 being status these aren't known. They change
         //sometimes, but what they mean is somewhat mysterious.
-        //System.out.println(String.format("%d %d %d %d %d %d", next_0, next_1, next_2, next_3, next_4, next_5));
+        System.out.println(String.format("%d %d %d %d %d %d", next_0, next_1, next_2, next_3, next_4, next_5));
          */
         byte_0 = next_0;
         status = next_1;
@@ -1791,5 +1903,4 @@ public class K40NanoDriver extends LaserCutter
     }
 
   }
-
 }


### PR DESCRIPTION
Include #107 (still pending) and #111 (minor fix). And includes the changes from #110. But, mostly modifies the K40Driver to use raster builder and thus fundamentally skips blank pixels to the extremes.  And requires a change to RasterPart to expose the image to the drivers.