### PR TITLE
Improve LTT driver

### DIFF
--- a/src/com/t_oster/liblasercut/LaserCutter.java
+++ b/src/com/t_oster/liblasercut/LaserCutter.java
@@ -147,6 +147,23 @@ public abstract class LaserCutter implements Cloneable, Customizable {
     public abstract double getBedHeight();
 
     /**
+     * Returns the required precision in px for interpolating curves as a poly-line.
+     * The default is 1, which means curves may be approximated within a tolerance of
+     * up to +- (1 inch / current DPI value) .
+     *
+     * A smaller value may be required if the driver does additional calculations
+     * with the path, such as computing an acceleration-limited velocity profile.
+     *
+     * A larger value may be helpful for cutters with very limited CPU power,
+     * which will slow down if a path has a high density of points per length.
+     * @see ShapeConverter.addShape() uses this value
+     * @return tolerance in machine pixels
+     */
+    public double getRequiredCurvePrecision() {
+      return 1;
+    }
+
+    /**
      * Override this method, return true and override the
      * estimateJobDuration-method to allow Programs to use
      * your driver to estimate the duration of a job before

--- a/src/com/t_oster/liblasercut/drivers/LaserToolsTechnicsCutter.java
+++ b/src/com/t_oster/liblasercut/drivers/LaserToolsTechnicsCutter.java
@@ -1111,7 +1111,6 @@ public class LaserToolsTechnicsCutter extends LaserCutter
         double absAngle = lastPoint.deltaToPrevious.absAngleTo(newPoint.deltaToPrevious);
         lastPoint.absAngleAtCorner = absAngle;
         // TODO: hardcoded factor: we actually use 5 times the configured smoothing tolerance!!!
-        // TODO: we need finer interpolation in ShapeConverter, or really use splines.
         // TODO: the following if-condition should be simplified or completely rewritten.
         if (absAngle * newLen > lengthTolerancePixels * 5 || absAngle > angleToleranceShort || (newLen > lengthTolerancePixels * 100 && absAngle > angleToleranceLong))
         {
@@ -1832,6 +1831,19 @@ public class LaserToolsTechnicsCutter extends LaserCutter
   {
     this.bedHeight = bedHeight;
   }
+
+  @Override
+  public double getRequiredCurvePrecision() {
+    if (this.useTangentCurves) {
+      // "Joint tangent curve" is used.
+      // we need finely spaced points so that the velocity calculations work correctly
+      return 0.2;
+    } else {
+      // classic polyline - better use lower precision to gain speed.
+      return 1;
+    }
+  }
+
   private static final Integer[] engraveShiftListDefault = new Integer[]
   {
     -2, -4, -7, -10, -13, -15, -17, -19, -21, -23

--- a/src/com/t_oster/liblasercut/drivers/LaserToolsTechnicsCutter.java
+++ b/src/com/t_oster/liblasercut/drivers/LaserToolsTechnicsCutter.java
@@ -1000,7 +1000,6 @@ public class LaserToolsTechnicsCutter extends LaserCutter
       if (lastPoint.deltaToPrevious != null)
       {
         double absAngle = lastPoint.deltaToPrevious.absAngleTo(newPoint.deltaToPrevious);
-        assert (absAngle < Math.PI / 2);
         lastPoint.absAngleAtCorner = absAngle;
         // TODO: hardcoded factor: we actually use 5 times the configured smoothing tolerance!!!
         // TODO: pass double values to LibLaserCut (or the raw splines, whatever), so that we can reinterpolate.

--- a/src/com/t_oster/liblasercut/drivers/LaserToolsTechnicsCutter.java
+++ b/src/com/t_oster/liblasercut/drivers/LaserToolsTechnicsCutter.java
@@ -730,6 +730,9 @@ public class LaserToolsTechnicsCutter extends LaserCutter
     {
       double len = point.deltaToPrevious.hypot();
       myAssert(len < 1e6 * maxDistance); // input points must not be more apart than 1e6*maxDistance
+      if (len == 0) {
+        continue;
+      }
       if (len < maxDistance)
       {
         pointsNew.add(point);
@@ -737,10 +740,14 @@ public class LaserToolsTechnicsCutter extends LaserCutter
       else
       {
         // in the end, we have the previous point, $numExtraPoints intermediate points, and the current point.
-        int numExtraPoints = (int) Math.floor(len / maxDistance);
+        // Number of intermediate points:
+        // 0 if len==maxDistance
+        // 1 for maxDist < len <= 2*maxDist
+        // ...
+        int numExtraPoints = (int) Math.ceil(len / maxDistance) - 1;
         for (int i = 0; i < numExtraPoints; i++)
         {
-          Point tmp = point.subtract(point.deltaToPrevious.scale((numExtraPoints - i + 1.f) / (2 + numExtraPoints)));
+          Point tmp = point.subtract(point.deltaToPrevious.scale((numExtraPoints - i + 0.d) / (1 + numExtraPoints)));
           PointWithSpeed intermediate = new PointWithSpeed(tmp.x, tmp.y);
           intermediate.absAngleAtCorner = 0;
           intermediate.deltaToPrevious = intermediate.subtract(previousPoint);

--- a/src/com/t_oster/liblasercut/drivers/LaserToolsTechnicsCutter_speedInterpolation.svg
+++ b/src/com/t_oster/liblasercut/drivers/LaserToolsTechnicsCutter_speedInterpolation.svg
@@ -87,9 +87,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1.4"
-     inkscape:cx="475.97737"
-     inkscape:cy="2766.2418"
+     inkscape:zoom="0.7"
+     inkscape:cx="869.77658"
+     inkscape:cy="515.69709"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="false" />
@@ -804,10 +804,22 @@
          x="25.123335"
          y="101.09097"
          style="stroke-width:0.26458332px"
-         id="tspan181">a_reduced = b * cos(alpha) + sqrt(b^2*(-1)*sin^2(alpha) + c_max^2)</tspan><tspan
+         id="tspan181">a_reduced_max = b * cos(alpha) + sqrt(b^2*(-1)*sin^2(alpha) + c_max^2)</tspan><tspan
          sodipodi:role="line"
          x="25.123335"
          y="105.50069"
+         style="stroke-width:0.26458332px"
+         id="tspan182" /><tspan
+         sodipodi:role="line"
+         x="25.123335"
+         y="109.91042"
+         style="stroke-width:0.26458332px"
+         id="tspan184">(The minimum possible value for a would be a_reduced_min = ...<tspan
+   style="-inkscape-font-specification:'Sans Bold';font-family:Sans;font-weight:bold;font-style:normal;font-stretch:normal;font-variant:normal"
+   id="tspan186"> - </tspan>sqrt(...) )</tspan><tspan
+         sodipodi:role="line"
+         x="25.123335"
+         y="114.32014"
          style="stroke-width:0.26458332px"
          id="tspan175" /></text>
     <text
@@ -868,14 +880,14 @@
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="34.895363"
-       y="131.94878"
+       x="18.642387"
+       y="130.43687"
        id="text159"><tspan
          sodipodi:role="line"
          id="tspan157"
-         x="34.895363"
-         y="131.94878"
-         style="stroke-width:0.26458332px">reduced a</tspan></text>
+         x="18.642387"
+         y="130.43687"
+         style="stroke-width:0.26458332px">a_reduced_max</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -916,5 +928,62 @@
          x="66.180466"
          y="135.7459"
          style="stroke-width:0.26458332px">c_max</tspan></text>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="path162"
+       d="m 58.586309,190.64291 -13.223633,-6.92005 -23.284231,6.92005 h 36.507864"
+       style="fill:none;fill-rule:evenodd;stroke:#0000ff;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       id="text166"
+       y="182.34923"
+       x="14.862625"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.26458332px"
+         y="182.34923"
+         x="14.862625"
+         id="tspan164"
+         sodipodi:role="line">a_reduced_min</tspan></text>
+    <text
+       id="text170"
+       y="194.5005"
+       x="18.940153"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.26458332px"
+         y="194.5005"
+         x="18.940153"
+         id="tspan168"
+         sodipodi:role="line">current (=maximum) b</tspan></text>
+    <text
+       id="text174"
+       y="190.0108"
+       x="31.118879"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.59079075px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.26458332px"
+         y="190.0108"
+         x="31.118879"
+         id="tspan172"
+         sodipodi:role="line">alpha</tspan></text>
+    <ellipse
+       ry="14.50855"
+       rx="14.452284"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#b3b3b3;stroke-width:0.96499997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="ellipse176"
+       cy="190.38177"
+       cx="58.211803" />
+    <text
+       id="text180"
+       y="187.28027"
+       x="55.219154"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.26458332px"
+         y="187.28027"
+         x="55.219154"
+         id="tspan178"
+         sodipodi:role="line">c_max</tspan></text>
   </g>
 </svg>

--- a/src/com/t_oster/liblasercut/platform/Circle.java
+++ b/src/com/t_oster/liblasercut/platform/Circle.java
@@ -1,0 +1,157 @@
+/**
+ * This file is part of LibLaserCut.
+ * Copyright (C) 2019 Max Gaukler <development@maxgaukler.de>
+ *
+ * LibLaserCut is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LibLaserCut is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+package com.t_oster.liblasercut.platform;
+
+import java.util.List;
+
+public class Circle
+{
+  public double radius = Double.NaN;
+  public Point center;
+
+  @Override
+  public String toString() {
+    return "Circle(radius=" + radius + ", center=" + center + ")";
+  }
+
+  /**
+   * Test if a point is on this circle (on the edge)
+   *
+   * @param p Point to test
+   * @param tolerance absolute tolerance for distance to circle
+   * @return
+   */
+  public boolean containsPoint(Point p, double tolerance)
+  {
+    return Math.abs(p.hypothenuseTo(center) - radius) < tolerance;
+  }
+
+  /**
+   * Detect a circle from a list of points with (roughly) equal distance
+   * This can be used to "undo" a circle-to-polyline conversion.
+   *
+   * Note that the current implementation is rather simple
+   *
+   * @param points List of points
+   * @param tolerance Maximum absolute deviation between points and the detected circle.
+   * @return null if no circle was found, Circle object otherwise.
+   */
+  public static Circle fromPointList(List<? extends Point> points, double tolerance)
+  {
+    Circle circle = new Circle();
+    if (points.size() < 8) {
+      // too few points
+      return null;
+    }
+    Point end = points.get(points.size() - 1);
+    Point start = points.get(0);
+    if (!start.equals(end)) {
+      // circle is not closed
+      return null;
+    }
+
+    // Compute the center:
+    // If the points are equally distributed, the center is the average of all points.
+    // To make that slightly more precise, we compute the weighted average of the segment midpoints, weighted by segment length.
+    // (The result is equal to reinterpolating the path with a constant and very small distance, and then computing the average).
+    circle.center = new Point(0, 0);
+    double length = 0;
+    double maxSegmentLength = 0;
+    Point pBefore = points.get(0);
+    for (Point p: points) {
+      double segmentLength = p.hypothenuseTo(pBefore);
+      circle.center.x += (p.x + pBefore.x) / 2 * segmentLength;
+      circle.center.y += (p.y + pBefore.y) / 2 * segmentLength;
+      if (segmentLength > maxSegmentLength) {
+        maxSegmentLength = segmentLength;
+      }
+      length += segmentLength;
+      pBefore = p;
+    }
+    circle.center = circle.center.scale(1 / length);
+
+    // Compute the radius and check that all points have the same radius (+/- tolerance).
+    double minRadiusSquare = Double.POSITIVE_INFINITY;
+    double avgRadiusSquare = 0;
+    double maxRadiusSquare = Double.NEGATIVE_INFINITY;
+    for (Point p: points) {
+      double radiusSquare = (circle.center.x - p.x) * (circle.center.x - p.x) + (circle.center.y - p.y) * (circle.center.y - p.y);
+      avgRadiusSquare += radiusSquare;
+      boolean radiusChanged = false;
+      if (radiusSquare < minRadiusSquare) {
+        minRadiusSquare = radiusSquare;
+        radiusChanged = true;
+      }
+      if (radiusSquare > maxRadiusSquare) {
+        maxRadiusSquare = radiusSquare;
+        radiusChanged = true;
+      }
+
+      // Note for the tolerance check:
+      //      maxRadius**2 - minRadius**2
+      //    = (minRadius + (maxRadius-minRadius))**2 - minRadius**2
+      //    = minRadius**2 + 2*minRadius*(maxRadius - minRadius) + (maxRadius - minRadius)**2 - minRadius**2
+      //    =  2*minRadius*(maxRadius - minRadius) + (maxRadius - minRadius)**2
+      // Because (maxRadius - minRadius) must be <= tolerance, this must be
+      //   <=  2*minRadius*(     tolerance       ) + (       tolerance     )**2
+
+      // Rewrite to get (maxRadius**2 - minRadius**2)**2 <= 4 * minRadius**2 * tolerance ** 2 + ...,
+      // where the rest .. can be neglected as minRadius is much larger than the tolerance.
+
+      if (radiusChanged)
+      {
+        // we check this as often as possible to abort early for non-circles
+        if ((maxRadiusSquare - minRadiusSquare) * (maxRadiusSquare - minRadiusSquare) > 4 * tolerance * tolerance * minRadiusSquare)
+        {
+          // shape is not circle-like within the tolerance (or our guess for the centerpoint was bad)
+          return null;
+        }
+        if (minRadiusSquare <= 45 * tolerance) {
+          // the circle is not much larger than the tolerance -- this does not make sense.
+          return null;
+        }
+      }
+    }
+    circle.radius = Math.sqrt(avgRadiusSquare / points.size());
+
+    // We now know that the radius is correct, i.e., all points are on the circle.
+    // However, if a segment is extremely long, the shape is still not a circle.
+    //
+    // Geometry (Pythagoras) leads to:
+    // radius ** 2 == maxSegmentLength ** 2 / 4 + (radius - deviationFromCircle)**2
+    // Therefore,
+    // maxSegmentLength ** 2 == 4 * (radius ** 2  - (radius - deviationFromCircle)**2)
+    //                       == 4 * (2*radius*deviationFromCircle + deviatonFromCircle**2)
+    //  where the last term can be neglected as the radius is much larger then the allowed deviation.
+    if (maxSegmentLength * maxSegmentLength > 8 * circle.radius * tolerance) {
+      // The current shape has constant "radius" but isn't circle-ish enough, e.g. a hexagon.
+      return null;
+    }
+
+    if (Math.abs(2*Math.PI*circle.radius - length) > 0.05 * length)
+    {
+      // The circumference doesn't match the radius  within 5% tolerance.
+      // This shape may be something odd like a circle that makes two revolutions.
+      return null;
+    }
+
+    // Everything is okay. Return the circle
+    return circle;
+  }
+}

--- a/src/com/t_oster/liblasercut/platform/Point.java
+++ b/src/com/t_oster/liblasercut/platform/Point.java
@@ -74,7 +74,11 @@ public class Point
     return true;
   }
 
-
+  @Override
+  public String toString()
+  {
+    return "Point(" + x + ", " + y + ")";
+  }
 
   public int compareTo(Point o)
   {

--- a/src/com/t_oster/liblasercut/utils/ShapeConverter.java
+++ b/src/com/t_oster/liblasercut/utils/ShapeConverter.java
@@ -18,6 +18,7 @@
  **/
 package com.t_oster.liblasercut.utils;
 
+import com.t_oster.liblasercut.LaserCutter;
 import com.t_oster.liblasercut.VectorPart;
 import java.awt.Shape;
 import java.awt.geom.AffineTransform;
@@ -36,15 +37,22 @@ public class ShapeConverter
   /**
    * Adds the given Shape to the given VectorPart by converting it to
    * lineto and moveto commands, whose lines differs not more than
-   * 1 pixel from the original shape.
+   * n pixels from the original shape. n is usually 1, but depends on the
+   * LaserCutter used.
    * 
    * @param shape the Shape to be added
    * @param vectorpart the Vectorpart the shape shall be added to
+   * @param cutter LaserCutter
    */
-  public void addShape(Shape shape, VectorPart vectorpart)
+  public void addShape(Shape shape, VectorPart vectorpart, LaserCutter cutter)
   {
     AffineTransform scale = AffineTransform.getScaleInstance(1, 1);
-    PathIterator iter = shape.getPathIterator(scale, 1);
+    double precision = 1;
+    if (cutter != null) // this "if" guard is only needed for compatibility - change to 'if (True)' after the deprecated addShape(Shape,VectorPart) interface has been removed
+    {
+      precision = cutter.getRequiredCurvePrecision();
+    }
+    PathIterator iter = shape.getPathIterator(scale, precision);
     double startx = 0;
     double starty = 0;
     int lastx = 0;
@@ -79,5 +87,18 @@ public class ShapeConverter
       }
       iter.next();
     }
+  }
+
+  /**
+   * Fallback method for compatibility with old VisiCut code.
+   * Remove this as soon as VisiCut uses the new interface of addShape.
+   * @param shape
+   * @param vectorpart
+   * @deprecated
+   */
+  @Deprecated
+  public void addShape(Shape shape, VectorPart vectorpart)
+  {
+    addShape(shape, vectorpart, null);
   }
 }

--- a/util/dump-epilog-raw/compare.sh
+++ b/util/dump-epilog-raw/compare.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# compare two raw epilog print files
+# usage: compare.sh fileA.prn fileB.prn
+
+# LICENSE: You may use this under either the the MIT License (see LICENSE file) or the GNU Lesser Public License (Version 3 or later, see ../../COPYING.LESSER).
+# SPDX-License-Identifier: MIT OR LGPL-3.0+
+
+set -e
+cd "$(dirname "$0")"
+diff <(./dump-epilog-raw-print-file.py "$1") <(./dump-epilog-raw-print-file.py "$2")

--- a/util/dump-ltt-raw/dump-ltt-raw-print-file.py
+++ b/util/dump-ltt-raw/dump-ltt-raw-print-file.py
@@ -111,7 +111,7 @@ def dump(filename, graph=False, showEngrave=False):
             print(s)
             raise Exception("did not get known start of command, but {:02X}".format(start))
 
-        commands={0x30: "Engrave line L2R", 0x31: "Engrave line R2L", 0x41: "Air Assist", 0x42: "end of file", 0x4A: "power", 0x4D: "job mode", 0x4E: "color", 0x50: "PPI", 0x53: "speed", 0x76:"version", 0x5041: "Pos. absolute", 0x5044:"Laser on", 0x5046: "End join", 0x504A: "Start join", 0x5045: "End speed", 0x5052: "Pos. relative", 0x5055: "Laser off", 0x5A41: "Focus?"}
+        commands={0x30: "Engrave line L2R", 0x31: "Engrave line R2L", 0x41: "Air Assist", 0x42: "end of file", 0x4A: "power", 0x4D: "job mode", 0x4E: "color", 0x50: "PPI", 0x53: "speed", 0x76:"version", 0x5041: "Pos. absolute", 0x5042: "Circle clockwise", 0x5043: "Circle counterclockwise", 0x5044:"Laser on", 0x5046: "End join", 0x504A: "Start join", 0x5045: "End speed", 0x5052: "Pos. relative", 0x5055: "Laser off", 0x5A41: "Focus?"}
         print("\n■ Command {:02X} ".format(cmd) + commands.get(cmd, ""))
 
         # two-byte commands:
@@ -195,7 +195,12 @@ def dump(filename, graph=False, showEngrave=False):
                 vEnd = 0;
                 dvBefore = 0;
                 dt = 1e-42;
-
+        elif cmd in [0x5042, 0x5043]:
+            # 16 byte data
+            print("relative endpoint")
+            readPrintXY()
+            print("relative center point")
+            readPrintXY()
         elif cmd == 0x6E:
             # 8 byte data
             readPrint(8)
@@ -297,12 +302,20 @@ def dump(filename, graph=False, showEngrave=False):
     plt.show()
 
     ## a = dv/dt = dv/ds * ds/dt = dv/ds * v
-    #a_approx = np.hstack((np.diff(speedx),0))/lens * speedx
-    ## j = da/dt = da/ds * ds/dt = da/ds * v
-    #j_approx = np.hstack((np.diff(a_approx),0))/lens * speedx
-    #plt.plot(np.cumsum(lens), a_approx,  'g.-', label="approx local accel")
-    #plt.plot(np.cumsum(lens), j_approx,  'm-', label="approx local jerk")
-    #plt.xlabel("total length")
+    #a_approx_x = np.hstack((np.diff(speedx),0)) / np.hstack((np.diff(t),0))
+    #a_approx_y = np.hstack((np.diff(speedy),0)) / np.hstack((np.diff(t),0))
+    #a_approx_xy = np.sqrt(a_approx_x ** 2 + a_approx_y ** 2)
+    #a_approx_xy_smoothed = np.convolve(a_approx_xy, np.ones((10,))/10, 'same')
+    ### j = da/dt = da/ds * ds/dt = da/ds * v
+    ##j_approx = np.hstack((np.diff(a_approx),0))/lens * speedx
+    #plt.plot(t, np.hstack((np.diff(speedx),0)) , 'r.-', label='x')
+    #plt.plot(t, np.hstack((np.diff(t),0)), 'b.-', label='y')
+    #plt.plot(t, a_approx_xy,  'g.-', label="absolute")
+    #plt.plot(t, a_approx_xy_smoothed,  'c.-', label="absolute, smoothed")
+    ##plt.plot(np.cumsum(lens), j_approx,  'm-', label="approx local jerk")
+    #plt.title("approx. acceleration over approx time  (very noisy due to quantisation)")
+    #plt.xlabel("time (approximate) in [px/%], not in seconds!")
+    #plt.ylabel("acceleration in [px/%^2 or some strange unit]")
     #plt.legend()
     #plt.show()
 


### PR DESCRIPTION
Now the speed on curves is at least as good as with the manufacturer's Windows driver.

Needs a one-line change to VisiCut to use the full potential (The laser driver can now specify the required precision of the path-to-polyine conversion in ShapeConverter), but is backwards compatible. I will push that as soon as the PR here is accepted.