### PR TITLE
README: Link to VisiCut's list of supported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,19 @@
 This is a library intended to provide suppport
 for Lasercutters on any platform.
 
-Currently it supports most Epilog Lasers,
-the current LAOS board. (www.laoslaser.org),
-the SmoothieBoard (www.smoothieware.org),
-K40, generic GRBL based boards,
-and some untested work-in-progress drivers like the Roland iModela and the Lasersaur.
-
-## Tested/Supported devices ##
-
-Manufacturer     | Model                   |  Interface       |  Driver               | Notes
-------------------------|-------------------------|--------------------|-----------------------|----------
-Epilog                  | Zing                       | Ethernet       | EplilogZing        |
-Epilog                  | Helix                      | Ethernet       | EpilogHelix        |
-Smoothieware   | Smoothieboard   | Ethernet       | SmoothieBoard |
-
-**If you run VisiCut successfully and your device is not yet listed, please edit this file and provide a pull request, so this stays up to date **
-
-
-
 It was created for VisiCut (http://visicut.org)
 but you are invited to use it for your own programs.
+
+Currently it supports older Epilog Lasers (Zing/Mini/Helix),
+the current LAOS board. (www.laoslaser.org),
+the SmoothieBoard (www.smoothieware.org),
+K40,
+generic GRBL based boards,
+LTT iLaser 4000,
+and some untested work-in-progress drivers like the Roland iModela and the Lasersaur.
+
+A detailed list of tested devices can be found in the VisiCut wiki:
+https://github.com/t-oster/VisiCut/wiki/Supported-Hardware
 
 If your Lasercutter is not supported, please contribute by implementing
 your driver as a subclass of the LaserCutter.java class.


### PR DESCRIPTION
Now there is only one list which is referenced in all places.

@t-oster Now that I have push rights to VisiCut, would it be possible to also get the same permissions to LibLaserCut?