### PR TITLE
Fix b/w engraving in convertRasterizableToVectorPart

### DIFF
--- a/src/main/java/de/thomas_oster/liblasercut/BlackWhiteRaster.java
+++ b/src/main/java/de/thomas_oster/liblasercut/BlackWhiteRaster.java
@@ -236,13 +236,13 @@ public class BlackWhiteRaster extends TimeIntensiveOperation implements Greyscal
   @Override
   public int getGreyScale(int x, int y)
   {
-    return getPixel(x, y);
+    return getPixel(x, y) * 255;
   }
 
   @Override
   public void setGreyScale(int x, int y, int grey)
   {
-    setPixel(x, y, grey);
+    setPixel(x, y, grey > 127 ? 1 : 0);
   }
 
 }

--- a/src/main/java/de/thomas_oster/liblasercut/BlackWhiteRaster.java
+++ b/src/main/java/de/thomas_oster/liblasercut/BlackWhiteRaster.java
@@ -236,13 +236,12 @@ public class BlackWhiteRaster extends TimeIntensiveOperation implements Greyscal
   @Override
   public int getGreyScale(int x, int y)
   {
-    return getPixel(x, y) * 255;
+    return isBlack(x,y) ? 0 : 255;
   }
 
   @Override
   public void setGreyScale(int x, int y, int grey)
   {
-    setPixel(x, y, grey > 127 ? 1 : 0);
+    setBlack(x, y, grey < 127);
   }
-
 }

--- a/src/main/java/de/thomas_oster/liblasercut/GreyscaleRaster.java
+++ b/src/main/java/de/thomas_oster/liblasercut/GreyscaleRaster.java
@@ -35,8 +35,16 @@ public interface GreyscaleRaster
 
   public int getWidth();
 
+  /**
+   * get greyscale value of pixel
+   * @return greyscale value: 0 (black) ... 255 (white)
+   */
   public int getGreyScale(int x, int y);
 
+  /**
+   * set greyscale value of pixel
+   * @param grey greyscale value: 0 (black) ... 255 (white) 
+   */
   public void setGreyScale(int x, int y, int grey);
 
   public int getHeight();

--- a/src/test/java/de/thomas_oster/liblasercut/BlackWhiteRasterTest.java
+++ b/src/test/java/de/thomas_oster/liblasercut/BlackWhiteRasterTest.java
@@ -80,6 +80,10 @@ public class BlackWhiteRasterTest
         assertTrue(ras.isBlack(x,y));
       }
     }
+    // raw bytes: 1 = black, 0 = white, 8 pixels per byte
+    assertEquals((byte) 0xff, ras.getByte(17, 42));
+    ras.setBlack(8*17+1, 42, false);
+    assertEquals((byte) 0b1011_1111, ras.getByte(17, 42));
     for (int x = 0; x < ras.getWidth(); x++)
     {
       for (int y = 0; y < ras.getHeight(); y++)
@@ -101,6 +105,25 @@ public class BlackWhiteRasterTest
         boolean black = ((Math.random() * 10) % 2 == 1);
         ras.setBlack(x, y, black);
         assertEquals(black, ras.isBlack(x, y));
+        // setGreyScale is mapped to {0, 255}.
+        // almost black -> black
+        ras.setGreyScale(x, y, 42);
+        assertEquals(0, ras.getGreyScale(x, y));
+        assertEquals(true, ras.isBlack(x, y));
+        assertEquals(1, ras.getPixel(x, y)); // note: meaning of getPixel() is opposite of isBlack()
+        // black
+        ras.setGreyScale(x, y, 0);
+        assertEquals(0, ras.getGreyScale(x, y));
+        assertEquals(true, ras.isBlack(x, y));
+        // white
+        ras.setGreyScale(x, y, 255);
+        assertEquals(255, ras.getGreyScale(x, y));
+        assertEquals(false, ras.isBlack(x, y));
+        // almost white
+        ras.setGreyScale(x, y, 200);
+        assertEquals(255, ras.getGreyScale(x, y));
+        assertEquals(false, ras.isBlack(x, y));
+        assertEquals(0, ras.getPixel(x, y)); // note: meaning of getPixel() is opposite of isBlack()
       }
     }
   }


### PR DESCRIPTION
All pixels inside the "bounding area" were engraved as if they were black.
Was maybe caused introduced by 0238bd1023cbc71fed9ae7901ba52fb47dc96186

Should fix https://github.com/t-oster/VisiCut/issues/562

Needs review - not properly tested, but seems to work at first look