### PR TITLE
Refactor laserproperty

### DIFF
--- a/src/main/java/de/thomas_oster/liblasercut/AbstractLaserProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/AbstractLaserProperty.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.logging.Logger;
 
 /**
  *
@@ -197,6 +198,49 @@ public class AbstractLaserProperty implements LaserProperty
     }
     return def;
   }
+  
+  /**
+   * get value in numeric datatype, if available
+   * @param key
+   * @return numeric value converted to Double; 0 if not present or a non-numeric datatype
+   */
+  public double getNumeric(String key)
+  {
+    if (getDouble(key) != null) {
+      return getDouble(key);
+    }
+    if (getFloat(key) != null) {
+      return getFloat(key);
+    }
+    if (getInteger(key) != null) {
+      return getInteger(key);
+    }
+    return 0;
+  }
+  
+  /**
+   * set existing property to numeric value, automatically converting to the used datatype.
+   * A warning is printed if the key does not exist.
+   * @param key
+   * @param value 
+   */
+  public void setNumeric(String key, double value)
+  {
+    if (getDouble(key) != null) {
+      this.setProperty(key, (Double) value);
+      return;
+    }
+    if (getFloat(key) != null) {
+      this.setProperty(key, (Float) (float) value);
+      return;
+    }
+    if (getInteger(key) != null) {
+      this.setProperty(key, (Integer) (int) value);
+      return;
+    }
+    Logger.getLogger(this.getClass().getName()).warning("tried to set nonexistent property " + key);
+  }
+  
   public Boolean getBoolean(String key)
   {
     return getBoolean(key, null);
@@ -254,6 +298,24 @@ public class AbstractLaserProperty implements LaserProperty
       return false;
     }
     return true;
+  }
+
+  @Override
+  public float getPower()
+  {
+    return (float) getNumeric("power");
+  }
+
+  @Override
+  public void setPower(float p)
+  {
+    setNumeric("power", p);
+  }
+
+  @Override
+  public float getSpeed()
+  {
+    return (float) getNumeric("speed");
   }
 
 }

--- a/src/main/java/de/thomas_oster/liblasercut/Customizable.java
+++ b/src/main/java/de/thomas_oster/liblasercut/Customizable.java
@@ -28,7 +28,10 @@ public interface Customizable {
      * Sets the property with the given key
      * a property may only be of the classes
      * Integer, Boolean, Double, Float and String
-     * and never set to null
+     * and never set to null.
+     * The type of <code>value</code> must be the same type as returned by
+     * <code>getProperty(key)</code>. It may be different for every
+     * implementation and every key.
      */
     void setProperty(String key, Object value);
     /**

--- a/src/main/java/de/thomas_oster/liblasercut/FloatPowerSpeedFocusFrequencyProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/FloatPowerSpeedFocusFrequencyProperty.java
@@ -40,6 +40,7 @@ public class FloatPowerSpeedFocusFrequencyProperty implements LaserProperty
    * Sets the Laserpower. Valid values are from 0 to 100.
    * In 3d-Raster mode, the intensity is scaled to this power setting
    */
+  @Override
   public void setPower(float power)
   {
     power = power < 0 ? 0 : power;
@@ -47,6 +48,7 @@ public class FloatPowerSpeedFocusFrequencyProperty implements LaserProperty
     this.power = power;
   }
 
+  @Override
   public float getPower()
   {
     return power;
@@ -62,6 +64,7 @@ public class FloatPowerSpeedFocusFrequencyProperty implements LaserProperty
     this.speed = speed;
   }
 
+  @Override
   public float getSpeed()
   {
     return speed;

--- a/src/main/java/de/thomas_oster/liblasercut/LaserProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/LaserProperty.java
@@ -44,4 +44,13 @@ public interface LaserProperty extends Cloneable, Customizable
   // Otherwise there is trouble in the GUI when it tries to compare laser settings
   @Override
   boolean equals(Object obj);
+  
+  
+  // The following functions are optional - if your device does not support speed/power, just make them return 100 (or an arbitrary value).
+  
+  public float getPower();
+  
+  public void setPower(float p);
+  
+  public float getSpeed();
 }

--- a/src/main/java/de/thomas_oster/liblasercut/PowerSpeedFocusProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/PowerSpeedFocusProperty.java
@@ -46,14 +46,16 @@ public class PowerSpeedFocusProperty implements LaserProperty
    * Sets the Laserpower. Valid values are from 0 to 100.
    * In 3d-Raster mode, the intensity is scaled to this power setting
    */
-  public void setPower(int power)
+  @Override
+  public void setPower(float power)
   {
     power = power < 0 ? 0 : power;
     power = power > 100 ? 100 : power;
-    this.power = power;
+    this.power = (int) power;
   }
 
-  public int getPower()
+  @Override
+  public float getPower()
   {
     return power;
   }
@@ -61,14 +63,15 @@ public class PowerSpeedFocusProperty implements LaserProperty
   /**
    * Sets the speed for the Laser. Valid values is from 0 to 100
    */
-  public void setSpeed(int speed)
+  public void setSpeed(float speed)
   {
     speed = speed < 0 ? 0 : speed;
     speed = speed > 100 ? 100 : speed;
-    this.speed = speed;
+    this.speed = (int) speed;
   }
 
-  public int getSpeed()
+  @Override
+  public float getSpeed()
   {
     return speed;
   }
@@ -132,11 +135,11 @@ public class PowerSpeedFocusProperty implements LaserProperty
   {
     if ("power".equals(name))
     {
-      return this.getPower();
+      return (Integer) (int) this.getPower();
     }
     else if ("speed".equals(name))
     {
-      return this.getSpeed();
+      return (Integer) (int) this.getSpeed();
     }
     else if ("focus".equals(name))
     {

--- a/src/main/java/de/thomas_oster/liblasercut/Raster3dPart.java
+++ b/src/main/java/de/thomas_oster/liblasercut/Raster3dPart.java
@@ -105,9 +105,9 @@ public class Raster3dPart extends RasterizableJobPart
   }
 
   @Override
-  public FloatPowerSpeedFocusProperty getPowerSpeedFocusPropertyForColor(int color)
+  public LaserProperty getPowerSpeedFocusPropertyForColor(int color)
   {
-    FloatPowerSpeedFocusProperty power = (FloatPowerSpeedFocusProperty) getLaserProperty().clone();
+    LaserProperty power = getLaserProperty().clone();
     // convert 0-255 into <max power>-0. i.e....
     //   - 0 (black) -> 100%
     //   - 127 (mid) -> 50%

--- a/src/main/java/de/thomas_oster/liblasercut/RasterPart.java
+++ b/src/main/java/de/thomas_oster/liblasercut/RasterPart.java
@@ -38,12 +38,7 @@ public class RasterPart extends RasterizableJobPart
     this.resolution = resolution;
     this.blackPixelProperty = laserProperty;
     this.whitePixelProperty = blackPixelProperty.clone();
-    if (whitePixelProperty instanceof FloatPowerSpeedFocusFrequencyProperty || whitePixelProperty instanceof FloatPowerSpeedFocusProperty) {
-      whitePixelProperty.setProperty("power", 0.0f);
-    }
-    else {
-      whitePixelProperty.setProperty("power", 0);
-    }
+    whitePixelProperty.setPower(0);
   }
 
 
@@ -93,11 +88,11 @@ public class RasterPart extends RasterizableJobPart
   }
   
   @Override
-  public FloatPowerSpeedFocusProperty getPowerSpeedFocusPropertyForColor(int color)
+  public LaserProperty getPowerSpeedFocusPropertyForColor(int color)
   {
     return color <= 127
-      ? (FloatPowerSpeedFocusProperty) blackPixelProperty
-      : (FloatPowerSpeedFocusProperty) whitePixelProperty;
+      ? blackPixelProperty
+      : whitePixelProperty;
   }
 
 }

--- a/src/main/java/de/thomas_oster/liblasercut/RasterizableJobPart.java
+++ b/src/main/java/de/thomas_oster/liblasercut/RasterizableJobPart.java
@@ -282,7 +282,7 @@ abstract public class RasterizableJobPart extends JobPart
    * @param y y coordinate of pixel
    * @return laser property appropriate for the color at this pixel
    */
-  public FloatPowerSpeedFocusProperty getPowerSpeedFocusPropertyForPixel(int x, int y)
+  public LaserProperty getPowerSpeedFocusPropertyForPixel(int x, int y)
   {
     return getPowerSpeedFocusPropertyForColor(image.getGreyScale(x, y));
   }
@@ -294,5 +294,5 @@ abstract public class RasterizableJobPart extends JobPart
    * @param color 0-255 value representing the color. 0 = black and 255 = white.
    * @return laser property appropriate for this color
    */
-  public abstract FloatPowerSpeedFocusProperty getPowerSpeedFocusPropertyForColor(int color);
+  public abstract LaserProperty getPowerSpeedFocusPropertyForColor(int color);
 }

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/EpilogCutter.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/EpilogCutter.java
@@ -26,6 +26,7 @@ package de.thomas_oster.liblasercut.drivers;
 
 import de.thomas_oster.liblasercut.*;
 import de.thomas_oster.liblasercut.platform.Point;
+import de.thomas_oster.liblasercut.platform.Util;
 import java.io.*;
 import java.net.InetSocketAddress;
 import java.net.Socket;
@@ -967,116 +968,18 @@ abstract class EpilogCutter extends LaserCutter
   @Override
   public int estimateJobDuration(LaserJob job)
   {
-    double VECTOR_MOVESPEED_X = 20000d / 4.5;
-    double VECTOR_MOVESPEED_Y = 10000d / 2.5;
-    double VECTOR_LINESPEED = 20000d / 36.8;
+    // It's not entirely clear how these values were determined. They are probably calibrated for the Epilog Zing.
+    double PX2MM_500DPI = Util.px2mm(1, 500);
+    double VECTOR_MOVESPEED_X = PX2MM_500DPI * 20000d / 4.5;
+    double VECTOR_MOVESPEED_Y = PX2MM_500DPI * 10000d / 2.5;
+    double VECTOR_LINESPEED = PX2MM_500DPI * 20000d / 36.8;
     double RASTER_LINEOFFSET = 0.08d;
-    double RASTER_LINESPEED = 100000d / ((268d / 50) - RASTER_LINEOFFSET);
+    double RASTER_LINESPEED = PX2MM_500DPI * 100000d / ((268d / 50) - RASTER_LINEOFFSET);
     //TODO: The Raster3d values are not tested yet, theyre just copies
-    double RASTER3D_LINEOFFSET = 0.08;
-    double RASTER3D_LINESPEED = 100000d / ((268d / 50) - RASTER3D_LINEOFFSET);
-
-    //Holds the current Laser Head position in Pixels
-    Point p = new Point(0, 0);
-
-    double result = 0;//usual offset
-    for (JobPart jp : job.getParts())
-    {
-      if (jp instanceof RasterPart)
-      {
-        RasterPart rp = (RasterPart) jp;
-        Point sp = rp.getRasterStart();
-        result += Math.max((p.x - sp.x) / VECTOR_MOVESPEED_X,
-          (p.y - sp.y) / VECTOR_MOVESPEED_Y);
-        double linespeed = (RASTER_LINESPEED * ((PowerSpeedFocusProperty) rp.getLaserProperty()).getSpeed()) / 100;
-        ByteArrayList line = new ByteArrayList(rp.getRasterWidth());
-        for (int y = 0; y < rp.getRasterHeight(); y++)
-        {//Find any black point
-          boolean lineEmpty = true;
-	  rp.getRasterLine(y, line);
-          for (byte b : line)
-          {
-            if (b != 0)
-            {
-              lineEmpty = false;
-              break;
-            }
-          }
-          if (!lineEmpty)
-          {
-            int w = rp.getRasterWidth();
-            result += RASTER_LINEOFFSET + (double) w / linespeed;
-            p.x = sp.y % 2 == 0 ? sp.x + w : sp.x;
-            p.y = sp.y + y;
-          }
-          else
-          {
-            result += RASTER_LINEOFFSET;
-          }
-        }
-      }
-      if (jp instanceof Raster3dPart)
-      {
-        Raster3dPart rp = (Raster3dPart) jp;
-        Point sp = rp.getRasterStart();
-        result += Math.max((p.x - sp.x) / VECTOR_MOVESPEED_X,
-          (p.y - sp.y) / VECTOR_MOVESPEED_Y);
-        double linespeed = (RASTER3D_LINESPEED * ((PowerSpeedFocusProperty) rp.getLaserProperty()).getSpeed()) / 100;
-	ByteArrayList line = new ByteArrayList(rp.getRasterWidth());
-        for (int y = 0; y < rp.getRasterHeight(); y++)
-        {//Check if
-          boolean lineEmpty = true;
-	  rp.getRasterLine(y, line);
-          for (byte b : line)
-          {
-            if (b != 0)
-            {
-              lineEmpty = false;
-              break;
-            }
-          }
-          if (!lineEmpty)
-          {
-            int w = rp.getRasterWidth();
-            result += RASTER3D_LINEOFFSET + (double) w / linespeed;
-            p.x = sp.y % 2 == 0 ? sp.x + w : sp.x;
-            p.y = sp.y + y;
-          }
-        }
-      }
-      if (jp instanceof VectorPart)
-      {
-        double speed = VECTOR_LINESPEED;
-        VectorPart vp = (VectorPart) jp;
-        for (VectorCommand cmd : vp.getCommandList())
-        {
-          switch (cmd.getType())
-          {
-            case SETPROPERTY:
-            {
-              speed = VECTOR_LINESPEED * ((PowerSpeedFocusFrequencyProperty) cmd.getProperty()).getSpeed() / 100;
-              break;
-            }
-            case MOVETO:
-              result += Math.max((p.x - cmd.getX()) / VECTOR_MOVESPEED_X,
-                (p.y - cmd.getY()) / VECTOR_MOVESPEED_Y);
-              p = new Point(cmd.getX(), cmd.getY());
-              break;
-            case LINETO:
-              double dist = distance(cmd.getX(), cmd.getY(), p);
-              p = new Point(cmd.getX(), cmd.getY());
-              result += dist / speed;
-              break;
-          }
-        }
-      }
-    }
-    return (int) result;
-  }
-
-  private double distance(double x, double y, Point p)
-  {
-    return Math.sqrt(Math.pow(p.x - x, 2) + Math.pow(p.y - y, 2));
+    double RASTER3D_LINEOFFSET = RASTER_LINEOFFSET;
+    double RASTER3D_LINESPEED = RASTER_LINESPEED;
+    
+    return estimateJobDuration(job, VECTOR_MOVESPEED_X, VECTOR_MOVESPEED_Y, VECTOR_LINESPEED, RASTER_LINEOFFSET, RASTER_LINESPEED, RASTER3D_LINEOFFSET, RASTER3D_LINESPEED);
   }
 
   @Override

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/EpilogCutter.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/EpilogCutter.java
@@ -487,9 +487,9 @@ abstract class EpilogCutter extends LaserCutter
       /* Raster Orientation: Printed in current direction */
       out.printf("\033*r0F");
       /* Raster power */
-      out.printf("\033&y%dP", prop.getPower());
+      out.printf("\033&y%dP", (int) prop.getPower());
       /* Raster speed */
-      out.printf("\033&z%dS", prop.getSpeed());
+      out.printf("\033&z%dS", (int) prop.getSpeed());
       /* Focus */
       out.printf("\033&y%dA", mm2focus(prop.getFocus()));
 
@@ -519,7 +519,7 @@ abstract class EpilogCutter extends LaserCutter
         {//Apperantly the other power settings are ignored, so we have to scale
           int x = line.get(n);
           x = x >= 0 ? x : 256 + x;
-          int scalex = x * prop.getPower() / 100;
+          int scalex = x * (int) prop.getPower() / 100;
           byte bx = (byte) (scalex < 128 ? scalex : scalex - 256);
           line.set(n, bx);
         }
@@ -584,9 +584,9 @@ abstract class EpilogCutter extends LaserCutter
     /* Raster Orientation: Printed in current direction */
     out.printf("\033*r0F");
     /* Raster power */
-    out.printf("\033&y%dP", prop.getPower());
+    out.printf("\033&y%dP", (int) prop.getPower());
     /* Raster speed */
-    out.printf("\033&z%dS", prop.getSpeed());
+    out.printf("\033&z%dS", (int) prop.getSpeed());
     /* Focus */
     out.printf("\033&y%dA", mm2focus(prop.getFocus()));
 
@@ -620,9 +620,9 @@ abstract class EpilogCutter extends LaserCutter
     /* Raster Orientation: Printed in current direction */
     out.printf("\033*r0F");
     /* Raster power */
-    out.printf("\033&y%dP", prop.getPower());
+    out.printf("\033&y%dP", (int) prop.getPower());
     /* Raster speed */
-    out.printf("\033&z%dS", prop.getSpeed());
+    out.printf("\033&z%dS", (int) prop.getSpeed());
     /* Focus */
     out.printf("\033&y%dA", mm2focus(prop.getFocus()));
 
@@ -756,13 +756,13 @@ abstract class EpilogCutter extends LaserCutter
             }
             if (currentPower == null || !currentPower.equals(p.getPower()))
             {
-              out.printf("YP%03d;", p.getPower());
-              currentPower = p.getPower();
+              out.printf("YP%03d;", (int) p.getPower());
+              currentPower = (int) p.getPower();
             }
             if (currentSpeed == null || !currentSpeed.equals(p.getSpeed()))
             {
-              out.printf("ZS%03d;", p.getSpeed());
-              currentSpeed = p.getSpeed();
+              out.printf("ZS%03d;", (int) p.getSpeed());
+              currentSpeed = (int) p.getSpeed();
             }
             break;
           }

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/GoldCutHPGL.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/GoldCutHPGL.java
@@ -138,8 +138,8 @@ public class GoldCutHPGL extends LaserCutter {
           break;
         case SETPROPERTY:
           PowerSpeedFocusFrequencyProperty p = (PowerSpeedFocusFrequencyProperty) cmd.getProperty();
-          setPower(out, p.getPower());
-          setSpeed(out, p.getSpeed());
+          setPower(out, (int) p.getPower());
+          setSpeed(out, (int) p.getSpeed());
           break;
       }
     }
@@ -193,7 +193,7 @@ public class GoldCutHPGL extends LaserCutter {
     boolean dirRight = true;
     Point rasterStart = rp.getRasterStart();
     PowerSpeedFocusProperty prop = (PowerSpeedFocusProperty) rp.getLaserProperty();
-    setSpeed(out, prop.getSpeed());
+    setSpeed(out, (int) prop.getSpeed());
     ByteArrayList bytes = new ByteArrayList(rp.getRasterWidth());
     for (int line = 0; line < rp.getRasterHeight(); line++) {
       Point lineStart = rasterStart.clone();
@@ -218,7 +218,7 @@ public class GoldCutHPGL extends LaserCutter {
               if (old == 0) {
                 move(out, lineStart.x + pix, lineStart.y, resolution);
               } else {
-                setPower(out, prop.getPower() * (0xFF & old) / 255);
+                setPower(out, (int) prop.getPower() * (0xFF & old) / 255);
                 line(out, lineStart.x + pix - 1, lineStart.y, resolution);
                 move(out, lineStart.x + pix, lineStart.y, resolution);
               }
@@ -226,7 +226,7 @@ public class GoldCutHPGL extends LaserCutter {
             }
           }
           //last point is also not "white"
-          setPower(out, prop.getPower() * (0xFF & bytes.get(bytes.size() - 1)) / 255);
+          setPower(out, (int) prop.getPower() * (0xFF & bytes.get(bytes.size() - 1)) / 255);
           line(out, lineStart.x + bytes.size() - 1, lineStart.y, resolution);
         } else {
           //move to the last nonempty point of the line
@@ -237,7 +237,7 @@ public class GoldCutHPGL extends LaserCutter {
               if (old == 0) {
                 move(out, lineStart.x + pix, lineStart.y, resolution);
               } else {
-                setPower(out, prop.getPower() * (0xFF & old) / 255);
+                setPower(out, (int) prop.getPower() * (0xFF & old) / 255);
                 line(out, lineStart.x + pix + 1, lineStart.y, resolution);
                 move(out, lineStart.x + pix, lineStart.y, resolution);
               }
@@ -245,7 +245,7 @@ public class GoldCutHPGL extends LaserCutter {
             }
           }
           //last point is also not "white"
-          setPower(out, prop.getPower() * (0xFF & bytes.get(0)) / 255);
+          setPower(out, (int) prop.getPower() * (0xFF & bytes.get(0)) / 255);
           line(out, lineStart.x, lineStart.y, resolution);
         }
       }
@@ -260,8 +260,8 @@ public class GoldCutHPGL extends LaserCutter {
     boolean dirRight = true;
     Point rasterStart = rp.getRasterStart();
     PowerSpeedFocusProperty prop = (PowerSpeedFocusProperty) rp.getLaserProperty();
-    setSpeed(out, prop.getSpeed());
-    setPower(out, prop.getPower());
+    setSpeed(out, (int) prop.getSpeed());
+    setPower(out, (int) prop.getPower());
     for (int line = 0; line < rp.getRasterHeight(); line++) {
       Point lineStart = rasterStart.clone();
       lineStart.y += line;
@@ -295,7 +295,7 @@ public class GoldCutHPGL extends LaserCutter {
               if (old == 0) {
                 move(out, lineStart.x + pix, lineStart.y, resolution);
               } else {
-                setPower(out, prop.getPower() * (0xFF & old) / 255);
+                setPower(out, (int) prop.getPower() * (0xFF & old) / 255);
                 line(out, lineStart.x + pix - 1, lineStart.y, resolution);
                 move(out, lineStart.x + pix, lineStart.y, resolution);
               }
@@ -303,7 +303,7 @@ public class GoldCutHPGL extends LaserCutter {
             }
           }
           //last point is also not "white"
-          setPower(out, prop.getPower() * (0xFF & bytes.get(bytes.size() - 1)) / 255);
+          setPower(out, (int) prop.getPower() * (0xFF & bytes.get(bytes.size() - 1)) / 255);
           line(out, lineStart.x + bytes.size() - 1, lineStart.y, resolution);
           //add some space to the right
           move(out, Math.min((int) Util.mm2px(bedWidth, resolution), (int) (lineStart.x + bytes.size() - 1 + Util.mm2px(this.addSpacePerRasterLine, resolution))), lineStart.y, resolution);
@@ -318,7 +318,7 @@ public class GoldCutHPGL extends LaserCutter {
               if (old == 0) {
                 move(out, lineStart.x + pix, lineStart.y, resolution);
               } else {
-                setPower(out, prop.getPower() * (0xFF & old) / 255);
+                setPower(out, (int) prop.getPower() * (0xFF & old) / 255);
                 line(out, lineStart.x + pix + 1, lineStart.y, resolution);
                 move(out, lineStart.x + pix, lineStart.y, resolution);
               }
@@ -326,7 +326,7 @@ public class GoldCutHPGL extends LaserCutter {
             }
           }
           //last point is also not "white"
-          setPower(out, prop.getPower() * (0xFF & bytes.get(0)) / 255);
+          setPower(out, (int) prop.getPower() * (0xFF & bytes.get(0)) / 255);
           line(out, lineStart.x, lineStart.y, resolution);
           //add some space to the left
           move(out, Math.max(0, (int) (lineStart.x - Util.mm2px(this.addSpacePerRasterLine, resolution))), lineStart.y, resolution);

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/IModelaProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/IModelaProperty.java
@@ -199,6 +199,24 @@ public class IModelaProperty implements LaserProperty
     }
     return true;
   }
+
+  @Override
+  public float getPower()
+  {
+    return 100;
+  }
+
+  @Override
+  public void setPower(float p)
+  {
+    // ignore the given value; we don't have an equivalent of "power".
+  }
+
+  @Override
+  public float getSpeed()
+  {
+    return (float) feedRate;
+  }
   
   
 

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/Lasersaur.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/Lasersaur.java
@@ -164,8 +164,8 @@ public class Lasersaur extends LaserCutter {
           break;
         case SETPROPERTY:
           PowerSpeedFocusFrequencyProperty p = (PowerSpeedFocusFrequencyProperty) cmd.getProperty();
-          setPower(out, p.getPower());
-          setSpeed(out, p.getSpeed());
+          setPower(out, (int) p.getPower());
+          setSpeed(out, (int) p.getSpeed());
           break;
       }
     }
@@ -203,7 +203,7 @@ public class Lasersaur extends LaserCutter {
     boolean dirRight = true;
     Point rasterStart = rp.getRasterStart();
     PowerSpeedFocusProperty prop = (PowerSpeedFocusProperty) rp.getLaserProperty();
-    setSpeed(out, prop.getSpeed());
+    setSpeed(out, (int) prop.getSpeed());
     ByteArrayList bytes = new ByteArrayList(rp.getRasterWidth());
     for (int line = 0; line < rp.getRasterHeight(); line++) {
       Point lineStart = rasterStart.clone();
@@ -228,7 +228,7 @@ public class Lasersaur extends LaserCutter {
               if (old == 0) {
                 move(out, lineStart.x + pix, lineStart.y, resolution);
               } else {
-                setPower(out, prop.getPower() * (0xFF & old) / 255);
+                setPower(out, (int) prop.getPower() * (0xFF & old) / 255);
                 line(out, lineStart.x + pix - 1, lineStart.y, resolution);
                 move(out, lineStart.x + pix, lineStart.y, resolution);
               }
@@ -236,7 +236,7 @@ public class Lasersaur extends LaserCutter {
             }
           }
           //last point is also not "white"
-          setPower(out, prop.getPower() * (0xFF & bytes.get(bytes.size() - 1)) / 255);
+          setPower(out, (int) prop.getPower() * (0xFF & bytes.get(bytes.size() - 1)) / 255);
           line(out, lineStart.x + bytes.size() - 1, lineStart.y, resolution);
         } else {
           //move to the last nonempty point of the line
@@ -247,7 +247,7 @@ public class Lasersaur extends LaserCutter {
               if (old == 0) {
                 move(out, lineStart.x + pix, lineStart.y, resolution);
               } else {
-                setPower(out, prop.getPower() * (0xFF & old) / 255);
+                setPower(out, (int) prop.getPower() * (0xFF & old) / 255);
                 line(out, lineStart.x + pix + 1, lineStart.y, resolution);
                 move(out, lineStart.x + pix, lineStart.y, resolution);
               }
@@ -255,7 +255,7 @@ public class Lasersaur extends LaserCutter {
             }
           }
           //last point is also not "white"
-          setPower(out, prop.getPower() * (0xFF & bytes.get(0)) / 255);
+          setPower(out, (int) prop.getPower() * (0xFF & bytes.get(0)) / 255);
           line(out, lineStart.x, lineStart.y, resolution);
         }
       }
@@ -270,8 +270,8 @@ public class Lasersaur extends LaserCutter {
     boolean dirRight = true;
     Point rasterStart = rp.getRasterStart();
     PowerSpeedFocusProperty prop = (PowerSpeedFocusProperty) rp.getLaserProperty();
-    setSpeed(out, prop.getSpeed());
-    setPower(out, prop.getPower());
+    setSpeed(out, (int) prop.getSpeed());
+    setPower(out, (int) prop.getPower());
     for (int line = 0; line < rp.getRasterHeight(); line++) {
       Point lineStart = rasterStart.clone();
       lineStart.y += line;
@@ -305,7 +305,7 @@ public class Lasersaur extends LaserCutter {
               if (old == 0) {
                 move(out, lineStart.x + pix, lineStart.y, resolution);
               } else {
-                setPower(out, prop.getPower() * (0xFF & old) / 255);
+                setPower(out, (int) prop.getPower() * (0xFF & old) / 255);
                 line(out, lineStart.x + pix - 1, lineStart.y, resolution);
                 move(out, lineStart.x + pix, lineStart.y, resolution);
               }
@@ -313,7 +313,7 @@ public class Lasersaur extends LaserCutter {
             }
           }
           //last point is also not "white"
-          setPower(out, prop.getPower() * (0xFF & bytes.get(bytes.size() - 1)) / 255);
+          setPower(out, (int) prop.getPower() * (0xFF & bytes.get(bytes.size() - 1)) / 255);
           line(out, lineStart.x + bytes.size() - 1, lineStart.y, resolution);
           //add some space to the right
           move(out, Math.min((int) Util.mm2px(bedWidth, resolution), (int) (lineStart.x + bytes.size() - 1 + Util.mm2px(this.addSpacePerRasterLine, resolution))), lineStart.y, resolution);
@@ -328,7 +328,7 @@ public class Lasersaur extends LaserCutter {
               if (old == 0) {
                 move(out, lineStart.x + pix, lineStart.y, resolution);
               } else {
-                setPower(out, prop.getPower() * (0xFF & old) / 255);
+                setPower(out, (int) prop.getPower() * (0xFF & old) / 255);
                 line(out, lineStart.x + pix + 1, lineStart.y, resolution);
                 move(out, lineStart.x + pix, lineStart.y, resolution);
               }
@@ -336,7 +336,7 @@ public class Lasersaur extends LaserCutter {
             }
           }
           //last point is also not "white"
-          setPower(out, prop.getPower() * (0xFF & bytes.get(0)) / 255);
+          setPower(out, (int) prop.getPower() * (0xFF & bytes.get(0)) / 255);
           line(out, lineStart.x, lineStart.y, resolution);
           //add some space to the left
           move(out, Math.max(0, (int) (lineStart.x - Util.mm2px(this.addSpacePerRasterLine, resolution))), lineStart.y, resolution);

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/MakeBlockXYPlotter.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/MakeBlockXYPlotter.java
@@ -236,12 +236,12 @@ public class MakeBlockXYPlotter extends LaserCutter
         case SETPROPERTY: // called once per part to set chosen properties
           MakeBlockXYPlotterProperty p = (MakeBlockXYPlotterProperty) cmd.getProperty(); // only set with LASER tool
           // ensure percent power
-          int pPercent = p.getPower();
+          int pPercent = (int) p.getPower();
           pPercent = pPercent<0?0:pPercent;
           pPercent = pPercent>100?100:pPercent;
-          this.setPower(pPercent);
+          this.setPower((int) pPercent);
           // ensure percent speed
-          int sPercent = p.getSpeed();
+          int sPercent = (int) p.getSpeed();
           sPercent = sPercent<0?0:sPercent;
           sPercent = sPercent>100?100:sPercent;
           int dPercent = 100-sPercent; // convert speed to delay
@@ -264,8 +264,8 @@ public class MakeBlockXYPlotter extends LaserCutter
     
     // called once per part to set chosen properties
     PowerSpeedFocusProperty prop = (PowerSpeedFocusProperty) rp.getLaserProperty();
-    this.setDelay(prop.getSpeed());
-    this.setPower(prop.getPower());
+    this.setDelay((int) prop.getSpeed());
+    this.setPower((int) prop.getPower());
     
     for (int line = 0; line < rp.getRasterHeight(); line++) {
       Point lineStart = rasterStart.clone();
@@ -300,7 +300,7 @@ public class MakeBlockXYPlotter extends LaserCutter
               if (old == 0) {
                 this.move(lineStart.x + pix, lineStart.y, resolution);
               } else {
-                this.setPower(prop.getPower() * (0xFF & old) / 255);
+                this.setPower((int) prop.getPower() * (0xFF & old) / 255);
                 this.line(lineStart.x + pix - 1, lineStart.y, resolution);
                 this.move(lineStart.x + pix, lineStart.y, resolution);
               }
@@ -308,7 +308,7 @@ public class MakeBlockXYPlotter extends LaserCutter
             }
           }
           //last point is also not "white"
-          this.setPower(prop.getPower() * (0xFF & bytes.get(bytes.size() - 1)) / 255);
+          this.setPower((int) prop.getPower() * (0xFF & bytes.get(bytes.size() - 1)) / 255);
           this.line(lineStart.x + bytes.size() - 1, lineStart.y, resolution);
           //add some space to the right
           this.move(Math.min((int) Util.mm2px(bedWidth, resolution), (int) (lineStart.x + bytes.size() - 1 + Util.mm2px(this.addSpacePerRasterLine, resolution))), lineStart.y, resolution);
@@ -323,7 +323,7 @@ public class MakeBlockXYPlotter extends LaserCutter
               if (old == 0) {
                 this.move(lineStart.x + pix, lineStart.y, resolution);
               } else {
-                this.setPower(prop.getPower() * (0xFF & old) / 255);
+                this.setPower((int) prop.getPower() * (0xFF & old) / 255);
                 this.line(lineStart.x + pix + 1, lineStart.y, resolution);
                 this.move(lineStart.x + pix, lineStart.y, resolution);
               }
@@ -331,7 +331,7 @@ public class MakeBlockXYPlotter extends LaserCutter
             }
           }
           //last point is also not "white"
-          this.setPower(prop.getPower() * (0xFF & bytes.get(0)) / 255);
+          this.setPower((int) prop.getPower() * (0xFF & bytes.get(0)) / 255);
           this.line(lineStart.x, lineStart.y, resolution);
           //add some space to the left
           this.move(Math.max(0, (int) (lineStart.x - Util.mm2px(this.addSpacePerRasterLine, resolution))), lineStart.y, resolution);

--- a/src/test/java/de/thomas_oster/liblasercut/RasterizableJobPartTest.java
+++ b/src/test/java/de/thomas_oster/liblasercut/RasterizableJobPartTest.java
@@ -93,8 +93,10 @@ public class RasterizableJobPartTest
   public void testGetRasterLine()
   {
     RasterElement element = getTest8bitRasterElement();
+    AbstractLaserProperty laserProperty = new AbstractLaserProperty();
+    laserProperty.addProperty("power", (Integer) 0); // laser property must have a "power" property to avoid warnings (engraving doesn't make sense if you can't change the power)
     RasterPart instance = new RasterPart(new GreyRaster(element),
-      new AbstractLaserProperty(), new Point(0,0), 500.0f);
+      laserProperty.clone(), new Point(0,0), 500.0f);
     List<Byte> line0 = instance.getRasterLine(0);
     assertEquals((byte)line0.get(0),(byte)-1);
     assertEquals((byte)line0.get(1),(byte)-1);
@@ -107,7 +109,7 @@ public class RasterizableJobPartTest
     assertEquals((byte)line0.get(8),(byte)-1);
     RasterElement element1bit = getTest1bitRasterElement();
     RasterPart instance1bit = new RasterPart(new GreyRaster(element1bit),
-      new AbstractLaserProperty(), new Point(0,0), 500.0f);
+      laserProperty.clone(), new Point(0,0), 500.0f);
     line0 = instance1bit.getRasterLine(0);
     assertEquals((byte)line0.get(0), (byte)0xc8); //0b11001000
     assertEquals((byte)line0.get(1), (byte)0x80); //0b10000000

--- a/src/test/java/de/thomas_oster/liblasercut/drivers/LaserCutterTest.java
+++ b/src/test/java/de/thomas_oster/liblasercut/drivers/LaserCutterTest.java
@@ -1,0 +1,100 @@
+/**
+ * This file is part of LibLaserCut.
+ * Copyright (C) 2020 Max Gaukler (development@maxgaukler.de)
+ *
+ * LibLaserCut is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LibLaserCut is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+package de.thomas_oster.liblasercut.drivers;
+
+import de.thomas_oster.liblasercut.GreyRaster;
+import de.thomas_oster.liblasercut.LaserJob;
+import de.thomas_oster.liblasercut.LaserProperty;
+import de.thomas_oster.liblasercut.RasterPart;
+import de.thomas_oster.liblasercut.VectorPart;
+import de.thomas_oster.liblasercut.platform.Point;
+import de.thomas_oster.liblasercut.platform.Util;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class LaserCutterTest extends Dummy
+{
+  @Test
+  public void testEstimateDuration()
+  {
+    LaserJob job = new LaserJob("", "", "");
+    LaserProperty prop = getLaserPropertyForVectorPart();
+    int speedPercent = 17;
+    prop.setProperty("speed", speedPercent);
+    // set resolution such that 42px = 1mm
+    double mm2px = 42;
+    double dpi = Util.dpmm2dpi(mm2px);
+    double expectedTime = 0;
+    
+    // 1. move mainly in x -> time == dx / move_speed_x
+    VectorPart p = new VectorPart(prop, dpi);
+    p.moveto(100 * mm2px, 1 * mm2px);
+    job.addPart(p);
+    expectedTime += 100/10;
+    assertEquals(expectedTime, this.estimateJobDuration(job, 10, 20, 0, 0, 0, 0, 0), 1);
+    
+    // 2. move mainly in y -> time == dy / move_speed_y
+    p.moveto(101 * mm2px, 101 * mm2px);
+    expectedTime += 100/20;
+    assertEquals(expectedTime, this.estimateJobDuration(job, 10, 20, 0, 0, 0, 0, 0), 1);
+    
+    // 3. cut line
+    p.lineto(401 * mm2px, 401 * mm2px);
+    double lineSpeed = 30;
+    expectedTime += Math.sqrt(2) * 300 / (lineSpeed * speedPercent / 100);
+    assertEquals(expectedTime, this.estimateJobDuration(job, 10, 20, lineSpeed, 0, 0, 0, 0), 1);
+    
+    // 4. engrave
+    LaserProperty rasterProp = getLaserPropertyForRasterPart();
+    speedPercent = 37;
+    rasterProp.setProperty("speed", speedPercent);
+    GreyRaster raster = new GreyRaster(123, 456);
+    int nonBlankLines = 61;
+    for (int x = 0; x < raster.getWidth(); x++)
+    {
+      for (int y = 0; y < raster.getHeight(); y++)
+      {
+        if (y <= nonBlankLines)
+        {
+          raster.setGreyScale(x, y, 0); // black = do engrave
+        }
+        else
+        {
+          raster.setGreyScale(x, y, 255); // white = don't engrave
+        }
+      }
+    }
+    RasterPart rp = new RasterPart(raster, rasterProp, new Point(501 * mm2px, 401 * mm2px), dpi);
+    job.addPart(rp);
+    expectedTime += 100 / 10; // move time to startpoint
+    assertEquals(expectedTime, this.estimateJobDuration(job, 10, 20, lineSpeed, 0, Double.POSITIVE_INFINITY, 0, 0), 1);
+    
+    // additionally consider the constant time per engrave line:
+    double rasterExtraTimePerLine = 17;
+    expectedTime += rasterExtraTimePerLine * raster.getHeight();
+    assertEquals(expectedTime, this.estimateJobDuration(job, 10, 20, lineSpeed, rasterExtraTimePerLine, Double.POSITIVE_INFINITY, 0, 0), 1);
+    
+    // additionally consider the finite engrave speed:
+    double rasterLineSpeed = 23;
+    expectedTime += nonBlankLines * raster.getWidth() / mm2px / (rasterLineSpeed * speedPercent / 100);
+    assertEquals(expectedTime, this.estimateJobDuration(job, 10, 20, lineSpeed, rasterExtraTimePerLine, rasterLineSpeed, 0, 0), 1);
+    
+    // Raster3dPart is not explicitly tested, it uses almost the same codepath as RasterPart.
+  }
+}


### PR DESCRIPTION
Some commits cherry-picked from my work towards #134 . Still needs testing to make sure nothing accidentally changed.

- LaserCutter.convertRasterizableToVectorPart also supports other property classes, not only float-based. This is useful for emulating raster support for lasercutters with integer power/speed settings or max. speed != 100.
- Now there's an easy function to call for computing the cutting time without duplicating lots of code, making #30 easy to fix. Just copy the example from EpilogCutter and adjust the calibration constants as documented in LaserCutter.estimateJobDuration. 