### PR TITLE
create test coverage statistics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,7 @@ jdk:
 script:
   - "./test.sh"
   - "mvn test"
+  # If codacy is configured, upload code coverage statistics, otherwise do nothing.
+  # Note: Due to a design defect, this cannot test code coverage of new pull requests!
+  # Codacy require a private API key that is passed as Travis-CI environment variable. For security reasons, this variable is unavailable on external pull requests.
+  - 'if [ -n "$CODACY_PROJECT_TOKEN" ]; then echo "Uploading coverage to codacy"; bash <(curl -Ls https://coverage.codacy.com/get.sh); fi'

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,14 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <!-- code coverage -->
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <version>0.8.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -113,6 +121,33 @@
         </repository>
     </distributionManagement>
     
+    
+    <build>
+        <plugins>
+            <!-- coverage -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.5</version>
+            <executions>
+                <execution>
+                    <id>agent</id>
+                    <goals>
+                        <goal>prepare-agent</goal>
+                    </goals>
+                </execution>
+                <execution>
+                    <id>report</id>
+                    <phase>prepare-package</phase>
+                    <goals>
+                        <goal>report</goal>
+                    </goals>
+                </execution>
+            </executions>
+            </plugin>
+        </plugins>
+    </build>
+  
     <profiles>
         <profile>
             <!-- only do sourcode, javadoc and gpg when releasing -->

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
                 </execution>
                 <execution>
                     <id>report</id>
-                    <phase>prepare-package</phase>
+                    <phase>test</phase>
                     <goals>
                         <goal>report</goal>
                     </goals>


### PR DESCRIPTION
I'd like to set up automatic test coverage reports for new pull requests.
This should be possible with codacy, as far as *internal* pull requests (not from external contributors with their own forks) are concerned. @t-oster can you please set up `CODACY_PROJECT_TOKEN` as a secret travis environment variable? https://support.codacy.com/hc/en-us/articles/207279819-Coverage 

However, it seems impossible by design with codacy to check coverage of *external* pull requests, which would actually be the most important part.