### PR TITLE
Join broken paths on inner-first sorting with tolerance

### DIFF
--- a/src/main/java/de/thomas_oster/liblasercut/LaserCutter.java
+++ b/src/main/java/de/thomas_oster/liblasercut/LaserCutter.java
@@ -219,7 +219,7 @@ public abstract class LaserCutter implements Cloneable, Customizable {
       public double lineTime(Point p, double px2mm, double speed)
       {
         Point pMm = p.scale(px2mm);
-        double time = currentPointMm.hypothenuseTo(pMm) / speed;
+        double time = currentPointMm.hypotTo(pMm) / speed;
         currentPointMm = pMm;
         return time;
       }

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/LaserToolsTechnicsCutter.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/LaserToolsTechnicsCutter.java
@@ -713,7 +713,7 @@ public class LaserToolsTechnicsCutter extends LaserCutter
     
     // the firmware works correctly up to this radius:
     final double CIRCLE_MAX_RADIUS_MM = 101.0;
-    final double radiusPx = center.hypothenuseTo(new Point(currentX, currentY));
+    final double radiusPx = center.hypotTo(new Point(currentX, currentY));
     final double radiusMm = Util.px2mm(radiusPx, resolution);
     if (radiusMm > CIRCLE_MAX_RADIUS_MM) {
         // CAUTION: The circle command is disabled for large radii as it seems broken in hardware: Large circles (radius > 105mm) cause so much acceleration (loud "BANG!" sound) that the mechanics may be damaged.

--- a/src/main/java/de/thomas_oster/liblasercut/platform/Circle.java
+++ b/src/main/java/de/thomas_oster/liblasercut/platform/Circle.java
@@ -38,7 +38,7 @@ public class Circle
    */
   public boolean containsPoint(Point p, double tolerance)
   {
-    return Math.abs(p.hypothenuseTo(center) - radius) < tolerance;
+    return Math.abs(p.hypotTo(center) - radius) < tolerance;
   }
 
   /**
@@ -74,7 +74,7 @@ public class Circle
     double maxSegmentLength = 0;
     Point pBefore = points.get(0);
     for (Point p: points) {
-      double segmentLength = p.hypothenuseTo(pBefore);
+      double segmentLength = p.hypotTo(pBefore);
       circle.center.x += (p.x + pBefore.x) / 2 * segmentLength;
       circle.center.y += (p.y + pBefore.y) / 2 * segmentLength;
       if (segmentLength > maxSegmentLength) {

--- a/src/main/java/de/thomas_oster/liblasercut/platform/Point.java
+++ b/src/main/java/de/thomas_oster/liblasercut/platform/Point.java
@@ -84,7 +84,7 @@ public class Point
    * compute euclidean distance to another point
    * @param p other point
    */
-  public double hypothenuseTo(Point p) {
+  public double hypotTo(Point p) {
     return this.subtract(p).hypot();
   }
   

--- a/src/main/java/de/thomas_oster/liblasercut/platform/Point.java
+++ b/src/main/java/de/thomas_oster/liblasercut/platform/Point.java
@@ -80,21 +80,21 @@ public class Point
     return "Point(" + x + ", " + y + ")";
   }
 
-  public int compareTo(Point o)
-  {
-    if (y < o.y) return -1;
-    if (y > o.y) return 1;
-    if (x < o.x) return -1;
-    if (x > o.x) return 1;
-    return 0;
-  }
-
     /**
    * compute euclidean distance to another point
    * @param p other point
    */
   public double hypothenuseTo(Point p) {
     return this.subtract(p).hypot();
+  }
+  
+  /**
+   * Compute Manhattan (1-norm) distance to another point.
+   * Fast approximation of euclidean distance.
+   * @return |self.x - p.x| + |self.y - p.y|
+   */
+  public double manhattanDistanceTo(Point p) {
+    return this.subtract(p).manhattanLength();
   }
 
   public Point add(Point p) {
@@ -135,6 +135,15 @@ public class Point
    */
   public double hypot() {
     return Math.sqrt(x*x + y*y);
+  }
+  
+  /**
+   * Get manhattan (1-norm) length.
+   * Useful as fast approximation of hypot()
+   * @return  |x| + |y|
+   */
+  public double manhattanLength() {
+    return Math.abs(x) + Math.abs(y);
   }
 
   /**

--- a/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/InnerFirstVectorOptimizer.java
+++ b/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/InnerFirstVectorOptimizer.java
@@ -174,7 +174,7 @@ public class InnerFirstVectorOptimizer extends VectorOptimizer
       Element.isClosedPath()
      */
     // do the work:
-    ArrayList<Element> result = OptimizerUtils.joinContiguousLoopElements(e);
+    ArrayList<Element> result = OptimizerUtils.joinContiguousLoopElements(e, 0.9);
     result.sort(new XMinComparator());
     result.sort(new YMinComparator());
     result.sort(new XMaxComparator());

--- a/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/NearestVectorOptimizer.java
+++ b/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/NearestVectorOptimizer.java
@@ -46,12 +46,12 @@ public class NearestVectorOptimizer extends VectorOptimizer
       int next = 0;
       //invert element direction if endpoint is nearer
       boolean invert = false;
-      double dst = -1;
-      for (int i = 1; i < e.size(); i++)
+      double dst = Double.POSITIVE_INFINITY;
+      for (int i = 0; i < e.size(); i++)
       {
-        //check distance to startpoint
-        double nd = dist(e.get(i).start, end);
-        if (nd < dst || dst == -1)
+        // check distance to next startpoint
+        double nd = e.get(i).start.hypothenuseTo(end);
+        if (nd < dst)
         {
           next = i;
           dst = nd;
@@ -59,14 +59,18 @@ public class NearestVectorOptimizer extends VectorOptimizer
         }
         if (!e.get(i).start.equals(e.get(i).getEnd()))
         {
-          //check distance to endpoint
-          nd = dist(e.get(i).getEnd(), end);
-          if (nd < dst || dst == -1)
+          // check distance to next endpoint
+          nd = e.get(i).getEnd().hypothenuseTo(end);
+          if (nd < dst)
           {
             next = i;
             dst = nd;
             invert = true;
           }
+        }
+        if (dst == 0)
+        {
+          break;
         }
       }
       //add next

--- a/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/NearestVectorOptimizer.java
+++ b/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/NearestVectorOptimizer.java
@@ -50,7 +50,7 @@ public class NearestVectorOptimizer extends VectorOptimizer
       for (int i = 0; i < e.size(); i++)
       {
         // check distance to next startpoint
-        double nd = e.get(i).start.hypothenuseTo(end);
+        double nd = e.get(i).start.hypotTo(end);
         if (nd < dst)
         {
           next = i;
@@ -60,7 +60,7 @@ public class NearestVectorOptimizer extends VectorOptimizer
         if (!e.get(i).start.equals(e.get(i).getEnd()))
         {
           // check distance to next endpoint
-          nd = e.get(i).getEnd().hypothenuseTo(end);
+          nd = e.get(i).getEnd().hypotTo(end);
           if (nd < dst)
           {
             next = i;

--- a/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/OptimizerUtils.java
+++ b/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/OptimizerUtils.java
@@ -20,162 +20,291 @@ package de.thomas_oster.liblasercut.vectoroptimizers;
 
 import de.thomas_oster.liblasercut.LaserProperty;
 import de.thomas_oster.liblasercut.platform.Point;
+import de.thomas_oster.liblasercut.vectoroptimizers.VectorOptimizer.Element;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class OptimizerUtils
 {
-
   /**
    * Given a list of Elements, combines Elements with matching start/end points
    * into single Elements. Elements with different props will never be joined.
-   *
-   * Joining will be perfect for any sequence of Elements which forms a perfect,
-   * straightforward loop within which every point matches precisely two
-   * Elements' start or end points. Any similar sequences that end on single
-   * points rather than completing a loop are also joined. In remaining cases,
-   * i.e., where more than two Elements meet at a single point, the Elements
-   * will not be joined.
+   * Joins or forks (if three or more paths meet at start/end, e.g. looking like Y),
+   * will never be joined.
    *
    * @param input List of Elements to join.
+   * @param tolerance start/end points within this distance (manhattan distance: |dx| + |dy|) are joined
    * @return ArrayList of joined Elements.
    */
-  public static ArrayList<VectorOptimizer.Element> joinContiguousLoopElements(
-    List<VectorOptimizer.Element> input)
+  public static ArrayList<Element> joinContiguousLoopElements(
+    List<Element> input, double tolerance)
   {
-    // For each prop encountered in the input, create an ArrayList containing
-    // two DirectedElements for each Element with the given prop. The two
-    // DirectedElements represent the two possible directions in which the
-    // Element could be executed (inverted or not).
-    HashMap<LaserProperty, ArrayList<DirectedElement>> propToElements = new HashMap<>();
-    for (int i = 0; i < input.size(); i++)
+    // Group elements by property, so that
+    // propToElements.get(property) == "list of all input[i] with input[i].prop == property"
+    Map<LaserProperty, ArrayList<Element>> propToElements = 
+      input.stream().collect(
+        Collectors.groupingBy(
+          el -> el.prop, Collectors.toCollection(ArrayList<Element>::new)
+        )
+      );
+
+    final ArrayList<Element> result = new ArrayList<>();
+    // for all elements with the same property:
+    for (ArrayList<Element> elements : propToElements.values())
     {
-      VectorOptimizer.Element element = input.get(i);
-      ArrayList<DirectedElement> list = propToElements.computeIfAbsent(element.prop, k -> new ArrayList<>());
-      list.add(new DirectedElement(i, element.start, element.getEnd(), false));
-      list.add(new DirectedElement(i, element.getEnd(), element.start, true));
-    }
+      // Now we can disregard properties, as all elementsWithSameProp reference Elements
+      // with identical properties
 
-    ArrayList<VectorOptimizer.Element> result = new ArrayList<>();
-    for (ArrayList<DirectedElement> directedElements : propToElements.values())
-    {
-      // Now we can disregard prop, as all directedElements reference Elements
-      // with identical prop.
+      // Group paths into two buckets:
+      //   closed -> move to result (no further processing required),
+      //   non-closed -> keep for the remaining computations
+      Map<Boolean, List<Element>> pathsGroupedByClosed = elements.stream()
+        .collect(Collectors.groupingBy(
+          (e) -> e.isClosedPath()
+        ));
+      List<Element> emptyList = new ArrayList<>(0);
+      result.addAll(pathsGroupedByClosed.getOrDefault(true, emptyList));
+      elements = new ArrayList<>(pathsGroupedByClosed.getOrDefault(false, emptyList));
 
-      // Sort directedElements according to their associated points, in order
-      // to allow efficient search for directedElements starting from a
-      // particular point later.
-      Collections.sort(directedElements);
-
-      // Find any start points shared by more than two directElements, and mark
-      // them as invalid. This will prevent any joining at this point.
-      for (int i = 0; i < directedElements.size(); i++)
+      // create an ArrayList containing two DirectedElements for each Element
+      // with the given prop. The two DirectedElements represent the two possible
+      // directions in which the Element could be executed (inverted or not).
+      // All points that have been removed are nulled.
+      ArrayList<DirectedElement> startAndEndPoints = new ArrayList<>(elements.size() * 2);
+      int i = 0;
+      for (Element element: elements)
       {
-        Point startPoint = directedElements.get(i).start;
-        int indexWithSameStartPoint = i;
-        for (int j = i + 1; j < directedElements.size(); j++)
-        {
-          if (!startPoint.equals(directedElements.get(j).start))
-          {
-            break;
-          }
-          indexWithSameStartPoint = j;
-        }
-        if (indexWithSameStartPoint + 1 - i > 2)
-        {
-          for (int j = i; j <= indexWithSameStartPoint; j++)
-          {
-            directedElements.get(i).valid = false;
-          }
-        }
-        i = indexWithSameStartPoint;
+        element.index = i;
+        startAndEndPoints.add(new DirectedElement(i, element.start, false));
+        startAndEndPoints.add(new DirectedElement(i, element.getEnd(), true));
+        i++;
       }
-
-      while (!directedElements.isEmpty())
+      // sort by x-coordinate to allow for binary search
+      Collections.sort(startAndEndPoints);
+      // The same list, but without nulling elements.
+      // Used for binary search, because binary-searching a "skip-list" is inefficient.
+      ArrayList<DirectedElement> originalStartAndEndPoints = new ArrayList<>(startAndEndPoints);
+      // add back-reference from elements to startAndEndPoints. This allows for faster deletion.
+      i = 0;
+      for (DirectedElement el: startAndEndPoints)
       {
-        // Grab an arbitrary element, setting it to null in the process to
-        // prevent it being seen again.
-        DirectedElement de = directedElements.remove(directedElements.size() - 1);
-        VectorOptimizer.Element current = input.get(de.index);
-        if (current == null)
+        if (el.inverted)
         {
-          continue;
+          elements.get(el.index).endIndex = i;
         }
-        input.set(de.index, null);
-
-        for (int pass = 0; pass < 2; pass++)
+        else
         {
-          // Search for any other elements that can be joined on to the end of
-          // this element.
-          boolean keepGoing = true;
-          while (keepGoing)
+          elements.get(el.index).startIndex = i;
+        }
+        i++;
+      }
+      
+      // Find the all start/end points near every start/end point, and merge if there is exactly 1 within the tolerance.
+      boolean somethingChanged = true;
+      while (somethingChanged)
+      {
+        somethingChanged = false;
+        for (Element current: elements)
+        {
+          if (current == null)
           {
-            Point endPoint = current.getEnd();
-            int i = binarySearch(directedElements, endPoint);
-            keepGoing = false;
-            while (i < directedElements.size()
-              && directedElements.get(i).valid
-              && directedElements.get(i).start.equals(endPoint))
+            // element was deleted
+            continue;
+          }
+          boolean hasAnyNeighbors = false;
+          // for "invert=1 (check end point)", "invert=0 (check start point)":
+          for (int invert = 1; invert >= 0; invert--)
+          {
+            // "Head" means the point we currently check (start or end).
+            Point currentHead = invert == 0 ? current.start : current.getEnd();
+            // How many other paths end or start are near the current head?
+            // If 0, there's nothing to do.
+            // If 1, merge the paths.
+            // If 2, we're at a fork, so don't merge.
+            //
+            // Optimization:
+            // We don't need to check if multiple end points meet because we don't join end-to-end, only start-to-end.
+            // End-to-end doesn't happen (except at forks) because
+            // nearest-first sorting would have inverted one of the paths, resulting in the end-to-start or start-to-end case.
+            // Due to symmetry, the end-to-start case is handled by the start-to-end case.
+            int pointsNearby = 0;
+            Element startNearCurrentHead = null;
+            Element endNearCurrentHead = null;
+
+            // Optimization: We can skip all points that are far left of the current head point.
+            int skipPoints = numElementsLeftOf(originalStartAndEndPoints, currentHead.x - tolerance);
+            for (DirectedElement e: startAndEndPoints.subList(skipPoints, startAndEndPoints.size()))
             {
-              int nextIndex = directedElements.get(i).index;
-              VectorOptimizer.Element next = input.get(nextIndex);
-              if (next == null)
+              // For every candidate point, check if it's nearby.
+              // If yes, remember it in startNearCurrentHead or endNearCurrentHead.
+              if (e == null || e.index == current.index)
               {
-                i++;
+                // skip removed (null) entries,
+                // skip current element
                 continue;
               }
-
-              // We've found an element (next) that can be joined onto the end of
-              // current! Do so, delete the element to prevent it from being seen
-              // again, and then go through the outer loop again to see if we can
-              // find yet another element to join on to the newly combined one.
-              input.set(nextIndex, null);
-              if (directedElements.get(i).inverted)
+              // skipPoints guarantees that all points are not too far left of the current head point.
+              assert e.start.x >= currentHead.x - tolerance;
+              if (e.start.x > currentHead.x + tolerance)
               {
-                next.invert();
+                // Current candidate is too far right.
+                // Optimization: All following candidates are even further more right, so we can stop here.
+                break;
               }
-              current.append(next);
-              keepGoing = true;
-              break;
+
+              if (pointsNearby >= 2)
+              {
+                break;
+              }
+              if (e.start.manhattanDistanceTo(currentHead) < tolerance)
+              {
+                pointsNearby++;
+                if (e.inverted)
+                {
+                  // e.start is actually an end point
+                  endNearCurrentHead = elements.get(e.index);
+                  assert endNearCurrentHead != null;
+                }
+                else
+                {
+                  // e.start is a start point
+                  startNearCurrentHead = elements.get(e.index);
+                  assert startNearCurrentHead != null;
+                }
+              }
+            }
+            if (pointsNearby >= 1) {
+              hasAnyNeighbors = true;
+            }
+
+//          int pointsNearby = startNearCurrentHead.size() + endNearCurrentHead.size();
+            if (pointsNearby == 1) {
+              // there is exactly one other start/end point nearby. join the paths.
+              Element merged;
+              if (startNearCurrentHead != null) {
+                // join current head to other.start. Note that head is "start" or "end" depending on invert.
+                Element other = startNearCurrentHead;
+                if (invert == 1)
+                {
+                  // because invert==1, "head" means "end".
+                  // join current.end ---- other.start
+                  startAndEndPoints.set(current.endIndex, null);
+                  startAndEndPoints.set(other.startIndex, null);
+                  current.append(other);
+                  // remove other
+                  elements.set(other.index, null);
+                  merged = current;
+                }
+                else
+                {
+                  // because invert==0, "head" means "start".
+                  // join current.start ---- other.start by reversing current.
+                  startAndEndPoints.set(current.startIndex, null);
+                  startAndEndPoints.set(other.startIndex, null);
+                  current.invert();
+                  current.append(other);
+                  // remove other
+                  elements.set(other.index, null);
+                  merged = current;
+                }
+              } else {
+                Element other = endNearCurrentHead;
+                // join current head to other.end. Note that head is "start" or "end" depending on invert.
+                if (invert == 1)
+                {
+                  // because invert==1, "head" means "end".
+                  // join current.end ---- other.end by reversing other.
+                  startAndEndPoints.set(current.endIndex, null);
+                  startAndEndPoints.set(other.endIndex, null);
+                  other.invert();
+                  current.append(other);
+                  merged = current;
+                  // remove other
+                  elements.set(other.index, null);
+                }
+                else
+                {
+                  // because invert==0, "head" means "start".
+                  // join other.end --- current.start
+                  startAndEndPoints.set(other.endIndex, null);
+                  startAndEndPoints.set(current.startIndex, null);
+                  other.append(current);
+                  merged = other;
+                  // remove current
+                  elements.set(current.index, null);
+                }
+              }
+              if (merged.isClosedPath())
+              {
+                // merged path is closed, move it to the result
+                result.add(merged);
+
+                elements.set(merged.index, null);
+                startAndEndPoints.set(merged.startIndex, null);
+                startAndEndPoints.set(merged.endIndex, null);
+              }
+              else
+              {
+                // merged path remains. update the start/end points in the list.
+                startAndEndPoints.get(merged.startIndex).inverted = false;
+                startAndEndPoints.get(merged.endIndex).inverted = true;
+                startAndEndPoints.get(merged.startIndex).index = merged.index;
+                startAndEndPoints.get(merged.endIndex).index = merged.index;
+              }
+              somethingChanged = true;
+              break; // The current element has been modified. Go on to the next element.
+              // This is optimal if the paths are already pre-sorted.
+            }
+            else
+            {
+              // pointsNearby != 1:
+              // There is either a fork (pointsNearby >= 2) or an end (pointsNearby == 0) at the current head point.
+              // Nothing to do. After the start point (invert==0),
+              // the same will be checked for the end point (invert==1)
+              // and then for the next point (i++).
             }
           }
-
-          if (pass == 1)
+          if (!hasAnyNeighbors)
           {
-            break;
+            // neither start nor end have any points nearby.
+            // -> information about this path is not relevant for remaining paths
+            result.add(current);
+            elements.set(current.index, null);
           }
-
-          // We couldn't find any more elements to join on. Either the loop is
-          // complete, or we've reached one end of an open polyline. Invert the
-          // path and take another run through in order to check for any more
-          // elements than can be joined on to the other end.
-          current.invert();
         }
-
-        result.add(current);
       }
+      // result.append( all elements != null )
+      elements.stream()
+        .filter(e -> e != null)
+        .collect(Collectors.toCollection(() -> result));
     }
+    
     return result;
   }
 
+
   /**
-   * Returns the index of the first DirectedElement whose start point is greater
-   * than or equal to the provided point p. Relies on the list already being
-   * sorted according to the natural ordering of DirectedElement.start.
-   * Collections.binarySearch cannot be used because it has undefined behaviour
-   * when several equal elements exist.
+   * Returns the number of elements at the head of the list that
+   * are left of the given x-coordinate. Relies on the list already being
+   * sorted according to x-coordinate. Elements must not be null.
+   * Similar to Collections.binarySearch, but with different return value.
    */
-  private static int binarySearch(ArrayList<DirectedElement> list, Point p)
+  private static int numElementsLeftOf(ArrayList<DirectedElement> list, Double x)
   {
+    if (list.isEmpty())
+    {
+      return 0;
+    }
     int start = -1; // Exclusive.
-    int end = list.size() - 1; // Inclusive.
+    int end = list.size() - 1; // Inclusive. Always points to a valid index.
 
     while (end - start > 1)
     {
       int mid = (start + end) / 2;
-      if (list.get(mid).start.compareTo(p) >= 0)
+      if (list.get(mid).start.x > x)
       {
         end = mid;
       }
@@ -187,45 +316,39 @@ public class OptimizerUtils
     return end;
   }
 
-  /**
+    /**
    * Represents an index within an ArrayList of Elements, combined with a
    * inverted/non-inverted flag. Contains the start and end points of the
    * referenced Element, switched if the inverted flag is set. Possesses a
-   * natural ordering based on this start point, allowing a sorted ArrayList of
-   * DirectedElements to be efficiently binary searched to find Elements
-   * starting or ending at a given point.
+   * pre-order based on the x-coordinate of the start point, allowing for a
+   * "weak" but consistent sorting of points. In this order, points near a given
+   * x-coordinate can be efficiently found by binary search.
+   *
+   * Note: this ordering is inconsistent with equals.
+   *
+   * Note that it is mathematically impossible to extend this idea to both x and
+   * y with a single order relation (sort so that nearby points would have nearby
+   * indices).
    */
-  private static class DirectedElement implements Comparable
+  private static class DirectedElement implements Comparable<DirectedElement>
   {
 
-    int index;
+    int index; // "pointer" to the respective Element
     Point start;
-    Point end;
     boolean inverted;
     boolean valid = true;
 
-    DirectedElement(int index, Point start, Point end, boolean inverted)
+    DirectedElement(int index, Point start, boolean inverted)
     {
       this.index = index;
       this.start = start;
-      this.end = end;
       this.inverted = inverted;
     }
 
     @Override
-    public int compareTo(Object o)
-    {
-      return compareTo((DirectedElement) o);
-    }
-
     public int compareTo(DirectedElement o)
     {
-      int cmp = start.compareTo(o.start);
-      if (cmp != 0)
-      {
-        return cmp;
-      }
-      return end.compareTo(o.end);
+      return Double.compare(start.x, o.start.x);
     }
   }
 }

--- a/src/test/java/de/thomas_oster/liblasercut/vectoroptimizers/InnerFirstVectorOptimizerTest.java
+++ b/src/test/java/de/thomas_oster/liblasercut/vectoroptimizers/InnerFirstVectorOptimizerTest.java
@@ -34,10 +34,12 @@ import org.junit.Test;
 public class InnerFirstVectorOptimizerTest
 {
 
+  final int SCALE = 2; // this must be greater than 2*(tolerance of joinContigousLoops)
+  
   @Test
   public void joinsSeparateLineSegments()
   {
-    ArrayList<Element> elements = new ArrayList();
+    ArrayList<Element> elements = new ArrayList<>();
     /*
       0 1 2 3
     0 *-----*
@@ -52,28 +54,29 @@ public class InnerFirstVectorOptimizerTest
       |     |
     5 *-----*
 
+     Note: these coordinates are later multiplied by 10
      */
-    elements.add(newElem(50, 0, 0, 3, 0));
-    elements.add(newElem(50, 3, 5, 3, 0));
-    elements.add(newElem(50, 3, 5, 0, 5));
-    elements.add(newElem(50, 0, 0, 0, 5));
+    elements.add(newElem(50, SCALE, 0, 0, 3, 0));
+    elements.add(newElem(50, SCALE, 3, 5, 3, 0));
+    elements.add(newElem(50, SCALE, 3, 5, 0, 5));
+    elements.add(newElem(50, SCALE, 0, 0, 0, 5));
 
-    elements.add(newElem(50, 2, 1, 1, 1));
-    elements.add(newElem(50, 1, 2, 2, 2));
-    elements.add(newElem(50, 2, 1, 2, 2));
-    elements.add(newElem(50, 1, 2, 1, 1));
+    elements.add(newElem(50, SCALE, 2, 1, 1, 1));
+    elements.add(newElem(50, SCALE, 1, 2, 2, 2));
+    elements.add(newElem(50, SCALE, 2, 1, 2, 2));
+    elements.add(newElem(50, SCALE, 1, 2, 1, 1));
 
-    elements.add(newElem(50, 1, 3, 2, 3));
-    elements.add(newElem(50, 2, 4, 2, 3));
-    elements.add(newElem(50, 2, 4, 1, 4));
-    elements.add(newElem(50, 1, 3, 1, 4));
+    elements.add(newElem(50, SCALE, 1, 3, 2, 3));
+    elements.add(newElem(50, SCALE, 2, 4, 2, 3));
+    elements.add(newElem(50, SCALE, 2, 4, 1, 4));
+    elements.add(newElem(50, SCALE, 1, 3, 1, 4));
 
     List<Element> sorted = new InnerFirstVectorOptimizer().sort(elements);
 
     assertEquals(3, sorted.size());
-    assertEquals(newElem(50, 1, 2, 1, 1, 2, 1, 2, 2, 1, 2), sorted.get(0));
-    assertEquals(newElem(50, 2, 4, 2, 3, 1, 3, 1, 4, 2, 4), sorted.get(1));
-    assertEquals(newElem(50, 3, 5, 3, 0, 0, 0, 0, 5, 3, 5), sorted.get(2));
+    assertEquals(newElem(50, SCALE, 2, 1, 1, 1, 1, 2, 2, 2, 2, 1), sorted.get(0));
+    assertEquals(newElem(50, SCALE, 1, 3, 2, 3, 2, 4, 1, 4, 1, 3), sorted.get(1));
+    assertEquals(newElem(50, SCALE, 0, 0, 3, 0, 3, 5, 0, 5, 0, 0), sorted.get(2));
   }
 
   @Test
@@ -95,28 +98,28 @@ public class InnerFirstVectorOptimizerTest
     5 *-----*
 
      */
-    elements.add(newElem(50, 0, 0, 3, 0));
-    elements.add(newElem(50, 3, 5, 3, 0));
-    elements.add(newElem(50, 3, 5, 0, 5));
-    elements.add(newElem(50, 0, 0, 0, 5));
+    elements.add(newElem(50, SCALE, 0, 0, 3, 0));
+    elements.add(newElem(50, SCALE, 3, 5, 3, 0));
+    elements.add(newElem(50, SCALE, 3, 5, 0, 5));
+    elements.add(newElem(50, SCALE, 0, 0, 0, 5));
 
-    elements.add(newElem(50, 2, 1, 1, 1));
-    elements.add(newElem(50, 1, 2, 1, 1));
-    elements.add(newElem(100, 2, 1, 2, 2));
-    elements.add(newElem(50, 2, 2, 1, 2));
+    elements.add(newElem(50, SCALE, 2, 1, 1, 1));
+    elements.add(newElem(50, SCALE, 1, 2, 1, 1));
+    elements.add(newElem(100, SCALE, 2, 1, 2, 2));
+    elements.add(newElem(50, SCALE, 2, 2, 1, 2));
 
-    elements.add(newElem(50, 1, 3, 2, 3));
-    elements.add(newElem(50, 2, 4, 2, 3));
-    elements.add(newElem(50, 2, 4, 1, 4));
-    elements.add(newElem(50, 1, 3, 1, 4));
+    elements.add(newElem(50, SCALE, 1, 3, 2, 3));
+    elements.add(newElem(50, SCALE, 2, 4, 2, 3));
+    elements.add(newElem(50, SCALE, 2, 4, 1, 4));
+    elements.add(newElem(50, SCALE, 1, 3, 1, 4));
 
     List<Element> sorted = new InnerFirstVectorOptimizer().sort(elements);
 
     assertEquals(4, sorted.size());
-    assertEquals(newElem(100, 2, 2, 2, 1), sorted.get(0));
-    assertEquals(newElem(50, 2, 1, 1, 1, 1, 2, 2, 2), sorted.get(1));
-    assertEquals(newElem(50, 2, 4, 2, 3, 1, 3, 1, 4, 2, 4), sorted.get(2));
-    assertEquals(newElem(50, 3, 5, 3, 0, 0, 0, 0, 5, 3, 5), sorted.get(3));
+    assertEquals(newElem(100, SCALE, 2, 1, 2, 2), sorted.get(0));
+    assertEquals(newElem(50, SCALE, 2, 2, 1, 2, 1, 1, 2, 1), sorted.get(1));
+    assertEquals(newElem(50, SCALE, 1, 3, 2, 3, 2, 4, 1, 4, 1, 3), sorted.get(2));
+    assertEquals(newElem(50, SCALE, 0, 0, 3, 0, 3, 5, 0, 5, 0, 0), sorted.get(3));
   }
 
   @Test
@@ -141,15 +144,15 @@ public class InnerFirstVectorOptimizerTest
 
     // Both elements starting at 0, 0; without the invert step to check for
     // matches at the start instead of just at the end, this would fail to join.
-    elements.add(newElem(50, 0, 0, 3, 0));
-    elements.add(newElem(50, 0, 0, 0, 3, 0, 5, 3, 5));
+    elements.add(newElem(50, SCALE, 0, 0, 3, 0));
+    elements.add(newElem(50, SCALE, 0, 0, 0, 3, 0, 5, 3, 5));
 
     for (int i = 1; i <= 2; i++)
     {
       for (int j = 1; j <= 3; j++)
       {
-        elements.add(newElem(50, i, j, i + 1, j));
-        elements.add(newElem(50, j, i, j, i + 1));
+        elements.add(newElem(50, SCALE, i, j, i + 1, j));
+        elements.add(newElem(50, SCALE, j, i, j, i + 1));
       }
     }
 
@@ -157,30 +160,34 @@ public class InnerFirstVectorOptimizerTest
 
     // Grid partially combined.
     assertEquals(9, sorted.size());
-    assertEquals(newElem(50, 2, 2, 1, 2), sorted.get(0));
-    assertEquals(newElem(50, 2, 2, 2, 1), sorted.get(1));
-    assertEquals(newElem(50, 1, 2, 1, 1, 2, 1), sorted.get(2));
-    assertEquals(newElem(50, 3, 2, 2, 2), sorted.get(3));
-    assertEquals(newElem(50, 3, 2, 3, 1, 2, 1), sorted.get(4));
-    assertEquals(newElem(50, 2, 3, 2, 2), sorted.get(5));
-    assertEquals(newElem(50, 2, 3, 1, 3, 1, 2), sorted.get(6));
-    assertEquals(newElem(50, 3, 2, 3, 3, 2, 3), sorted.get(7));
+    assertEquals(newElem(50, SCALE, 1, 2, 2, 2), sorted.get(0));
+    assertEquals(newElem(50, SCALE, 2, 1, 2, 2), sorted.get(1));
+    assertEquals(newElem(50, SCALE, 2, 1, 1, 1, 1, 2), sorted.get(2));
+    assertEquals(newElem(50, SCALE, 2, 2, 3, 2), sorted.get(3));
+    assertEquals(newElem(50, SCALE, 2, 1, 3, 1, 3, 2), sorted.get(4));
+    assertEquals(newElem(50, SCALE, 2, 2, 2, 3), sorted.get(5));
+    assertEquals(newElem(50, SCALE, 1, 2, 1, 3, 2, 3), sorted.get(6));
+    assertEquals(newElem(50, SCALE, 2, 3, 3, 3, 3, 2), sorted.get(7));
 
     // Polyline combined.
-    assertEquals(newElem(50, 3, 5, 0, 5, 0, 3, 0, 0, 3, 0), sorted.get(8));
+    assertEquals(newElem(50, SCALE, 3, 0, 0, 0, 0, 3, 0, 5, 3, 5), sorted.get(8));
   }
 
-  private static Element newElem(int power, int x1, int y1, int... moves)
+  /**
+   * Construct a new path
+   * @param power laser power
+   * @param scale all coordinates are multiplied by this factor
+   */
+  private static Element newElem(int power, int scale, int x1, int y1, int... moves)
   {
     Element ret = new Element();
 
-    ret.start = new Point(x1, y1);
+    ret.start = new Point(scale * x1, scale * y1);
 
-    ret.moves = new ArrayList();
     assertEquals(0, moves.length % 2);
     for (int i = 0; i < moves.length; i += 2)
     {
-      ret.moves.add(new Point(moves[i], moves[i + 1]));
+      ret.addPoint(new Point(scale * moves[i], scale * moves[i + 1]));
     }
 
     PowerSpeedFocusProperty prop = new PowerSpeedFocusProperty();
@@ -210,8 +217,8 @@ public class InnerFirstVectorOptimizerTest
     {
       for (int j = 0; j <= 4; j++)
       {
-        elements.add(newElem(50, 50 * i, 50 * j, 50 * (i + 1), 50 * j));
-        elements.add(newElem(50, 50 * j, 50 * i, 50 * j, 50 * (i + 1)));
+        elements.add(newElem(50, SCALE, 50 * i, 50 * j, 50 * (i + 1), 50 * j));
+        elements.add(newElem(50, SCALE, 50 * j, 50 * i, 50 * j, 50 * (i + 1)));
       }
     }
 
@@ -229,38 +236,38 @@ public class InnerFirstVectorOptimizerTest
     final int OX = SX * 3;
     final int OY = 0;
     final int S = 3;
-    for (int i = 0; i <= 5; i++)
+    for (int i = 0; i <= 2000; i++)
     {
-      for (int j = 0; j <= 5; j++)
+      for (int j = 0; j <= 2000; j++)
       {
         if (Math.abs(i - j) < S)
         {
-          elements.add(newElem(
-            50, OX + SX * (2 * i - j), OY + SY * (3 * j),
+          elements.add(newElem(50, SCALE, OX + SX * (2 * i - j), OY + SY * (3 * j),
             OX + SX * (2 * i - j - 1), OY + SY * (3 * j + 1)));
         }
         if (Math.abs(i - j + 0.5) < S + 0.3 && i < 5)
         {
-          elements.add(newElem(
-            50, OX + SX * (2 * i - j), OY + SY * (3 * j),
+          elements.add(newElem(50, SCALE, OX + SX * (2 * i - j), OY + SY * (3 * j),
             OX + SX * (2 * i - j + 1), OY + SY * (3 * j + 1)));
         }
         if (Math.abs(i - j - 0.5) < S + 0.3 && j < 5)
         {
-          elements.add(newElem(
-            50, OX + SX * (2 * i - j - 1), OY + SY * (3 * j + 1),
+          elements.add(newElem(50, SCALE, OX + SX * (2 * i - j - 1), OY + SY * (3 * j + 1),
             OX + SX * (2 * i - j - 1), OY + SY * (3 * j + 3)));
         }
       }
     }
 
+    //drawAnimation("hexagon_unsorted", elements);
+    System.out.println("hey");
+    System.out.println(elements.size());
     List<Element> sorted = new InnerFirstVectorOptimizer().sort(elements);
-
-    drawAnimation("hexagon", sorted);
+    System.out.println("ho");
+    //drawAnimation("hexagon", sorted);
   }
 
   private static final int BORDER = 5;
-  private static final int ANTIALIAS = 3;
+  private static final int ANTIALIAS = 1;
 
   private static void drawAnimation(String name, List<Element> sorted)
     throws IOException
@@ -271,19 +278,20 @@ public class InnerFirstVectorOptimizerTest
     for (Element polyline : sorted)
     {
       bb.add(polyline.start);
-      for (Point p : polyline.moves)
+      for (Point p : polyline.getMoves())
       {
         bb.add(p);
       }
     }
-    String dimensions = ANTIALIAS * (bb.getXMax() + 2 * BORDER + 1) + "x"
-      + ANTIALIAS * (bb.getYMax() + 2 * BORDER + 1);
-    String finalDimensions = (bb.getXMax() + 2 * BORDER + 1) + "x"
-      + (bb.getYMax() + 2 * BORDER + 1);
+    String dimensions = ANTIALIAS * ((int) bb.getXMax() + 2 * BORDER + 1) + "x"
+      + ANTIALIAS * ((int) bb.getYMax() + 2 * BORDER + 1);
+    String finalDimensions = ((int) bb.getXMax() + 2 * BORDER + 1) + "x"
+      + ((int) bb.getYMax() + 2 * BORDER + 1);
 
     PrintWriter out = new PrintWriter(
       new BufferedWriter(new FileWriter(name + "_animation_gen.sh")));
 
+    out.printf("set -e\n");
     out.printf("rm -f frame*.png\n");
 
     final String CMD = "convert -size " + dimensions + " xc:Yellow +antialias "
@@ -296,7 +304,7 @@ public class InnerFirstVectorOptimizerTest
     for (Element polyline : sorted)
     {
       Point prev = polyline.start;
-      for (Point p : polyline.moves)
+      for (Point p : polyline.getMoves())
       {
         Point end = null;
         for (int f = 1; f <= F; f++)
@@ -325,8 +333,7 @@ public class InnerFirstVectorOptimizerTest
 
   private static String p2s(Point p)
   {
-    final int O = 5;
-    return " " + (ANTIALIAS * (p.x + BORDER) + ANTIALIAS / 2)
-      + "," + (ANTIALIAS * (p.y + BORDER) + ANTIALIAS / 2);
+    return " " + (int) (ANTIALIAS * (p.x + BORDER) + ANTIALIAS / 2)
+      + "," + (int) (ANTIALIAS * (p.y + BORDER) + ANTIALIAS / 2);
   }
 }


### PR DESCRIPTION
In some files, paths are chopped into pieces, which confuses the INNER_FIRST algorithm. Previously, INNER_FIRST only merged exactly identical start/end points, which is problematic: In floating point, ((a + b) + c) == ((a + b) + c) isn't always true. For example, in files from CAD ( [example](https://www.thingiverse.com/download:1984102) ) or in formats that mix absolute and relative coordinates (importing CAD files to Inkscape, see [problems.zip](https://github.com/t-oster/LibLaserCut/files/4434731/problems.zip)). 

The problem got a lot worse since Point in LibLaserCut was changed from int to double (which was required for post-processing in the LaserToolsTechnics driver). Before, most 

My proposed change introduces a tolerance of 0.9 pixels (in the current DPI), so about 0.02mm for 1000dpi. Fuzzy comparison comes at the cost of CPU time: INNER_FIRST sorting is now significantly slower than the old algorithm from #84 , but only about 2-5x slower than NEAREST (which has quadratic complexity).

The example file has 20.000 paths which are joined into 380. This takes about 10 seconds to process, compared to 3 seconds for NEAREST. For comparison, many operations in Inkscape on this file are slower. 
The time grows roughly quadratic with the number of paths: The worst case I tested is 80.000 paths. Then, the whole VisiCut UI is already slow but the algorithm still more or less works (about 180 seconds for INNER_FIRST, compared to 60 seconds for NEAREST).
This is okay-ish but still much better than before if you consider that it saves lots of frustration and laser time.

There is some room for optimization because currently every path is compared to almost every other one, while actually we could sort the elements by x-position and then only compare elements with similar x-coordinates. Implementing this will be some fun because we have to keep the list sorted while modifying elements.

As a side note, I don't understand why NearestVectorOptimizer is fastest with its current choice of ArrayList than with any other possibility I tried (especially ArrayList with setting to null instead of removing, and also LinkedList). Heavily using .remove() shouldn't be the best idea for ArrayList...