### PR TITLE
Fixed dangling Javadoc comments

### DIFF
--- a/copyrightheader
+++ b/copyrightheader
@@ -1,18 +1,18 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */

--- a/src/main/java/de/thomas_oster/liblasercut/AbstractLaserProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/AbstractLaserProperty.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 
 package de.thomas_oster.liblasercut;
 

--- a/src/main/java/de/thomas_oster/liblasercut/BlackWhiteRaster.java
+++ b/src/main/java/de/thomas_oster/liblasercut/BlackWhiteRaster.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 
 package de.thomas_oster.liblasercut;
 

--- a/src/main/java/de/thomas_oster/liblasercut/ByteArrayList.java
+++ b/src/main/java/de/thomas_oster/liblasercut/ByteArrayList.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 /*
  * Copyright 2016 Google Inc.
  */

--- a/src/main/java/de/thomas_oster/liblasercut/Customizable.java
+++ b/src/main/java/de/thomas_oster/liblasercut/Customizable.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut;
 
 /**

--- a/src/main/java/de/thomas_oster/liblasercut/FloatPowerSpeedFocusFrequencyProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/FloatPowerSpeedFocusFrequencyProperty.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut;
 
 /**

--- a/src/main/java/de/thomas_oster/liblasercut/FloatPowerSpeedFocusProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/FloatPowerSpeedFocusProperty.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut;
 
 /**

--- a/src/main/java/de/thomas_oster/liblasercut/GreyRaster.java
+++ b/src/main/java/de/thomas_oster/liblasercut/GreyRaster.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 
 package de.thomas_oster.liblasercut;
 

--- a/src/main/java/de/thomas_oster/liblasercut/GreyscaleRaster.java
+++ b/src/main/java/de/thomas_oster/liblasercut/GreyscaleRaster.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut;
 
 /**

--- a/src/main/java/de/thomas_oster/liblasercut/IllegalJobException.java
+++ b/src/main/java/de/thomas_oster/liblasercut/IllegalJobException.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 /*
  * To change this template, choose Tools | Templates
  * and open the template in the editor.

--- a/src/main/java/de/thomas_oster/liblasercut/JobPart.java
+++ b/src/main/java/de/thomas_oster/liblasercut/JobPart.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 
 package de.thomas_oster.liblasercut;
 

--- a/src/main/java/de/thomas_oster/liblasercut/LaserCutter.java
+++ b/src/main/java/de/thomas_oster/liblasercut/LaserCutter.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 /*
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
@@ -190,8 +190,8 @@ public abstract class LaserCutter implements Cloneable, Customizable {
      */
   protected int estimateJobDuration(LaserJob job, double moveSpeedX, double moveSpeedY, double vectorLineSpeed, double rasterExtraTimePerLine, double rasterLineSpeed, double raster3dExtraTimePerLine, double raster3dLineSpeed)
   {
-    /**
-     * Helper object for computing the duration of lineto() / moveto() commands
+    /*
+      Helper object for computing the duration of lineto() / moveto() commands
      */
     class TimeComputation
     {

--- a/src/main/java/de/thomas_oster/liblasercut/LaserJob.java
+++ b/src/main/java/de/thomas_oster/liblasercut/LaserJob.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 /*
  * To change this template, choose Tools | Templates
  * and open the template in the editor.

--- a/src/main/java/de/thomas_oster/liblasercut/LaserProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/LaserProperty.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut;
 
 /**

--- a/src/main/java/de/thomas_oster/liblasercut/LibInfo.java
+++ b/src/main/java/de/thomas_oster/liblasercut/LibInfo.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut;
 
 import de.thomas_oster.liblasercut.drivers.*;

--- a/src/main/java/de/thomas_oster/liblasercut/OptionSelector.java
+++ b/src/main/java/de/thomas_oster/liblasercut/OptionSelector.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut;
 
 public class OptionSelector

--- a/src/main/java/de/thomas_oster/liblasercut/PowerSpeedFocusFrequencyProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/PowerSpeedFocusFrequencyProperty.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut;
 
 /**

--- a/src/main/java/de/thomas_oster/liblasercut/PowerSpeedFocusProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/PowerSpeedFocusProperty.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut;
 
 /**

--- a/src/main/java/de/thomas_oster/liblasercut/ProgressListener.java
+++ b/src/main/java/de/thomas_oster/liblasercut/ProgressListener.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut;
 
 /**

--- a/src/main/java/de/thomas_oster/liblasercut/ProgressListenerDummy.java
+++ b/src/main/java/de/thomas_oster/liblasercut/ProgressListenerDummy.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2020 Max Gaukler (development@maxgaukler.de)
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2020 Max Gaukler (development@maxgaukler.de)
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut;
 
 

--- a/src/main/java/de/thomas_oster/liblasercut/Raster3dPart.java
+++ b/src/main/java/de/thomas_oster/liblasercut/Raster3dPart.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut;
 
 import de.thomas_oster.liblasercut.platform.Point;

--- a/src/main/java/de/thomas_oster/liblasercut/RasterBuilder.java
+++ b/src/main/java/de/thomas_oster/liblasercut/RasterBuilder.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 
 package de.thomas_oster.liblasercut;
 

--- a/src/main/java/de/thomas_oster/liblasercut/RasterElement.java
+++ b/src/main/java/de/thomas_oster/liblasercut/RasterElement.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 
 package de.thomas_oster.liblasercut;
 

--- a/src/main/java/de/thomas_oster/liblasercut/RasterPart.java
+++ b/src/main/java/de/thomas_oster/liblasercut/RasterPart.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut;
 
 import de.thomas_oster.liblasercut.platform.Point;

--- a/src/main/java/de/thomas_oster/liblasercut/RasterizableJobPart.java
+++ b/src/main/java/de/thomas_oster/liblasercut/RasterizableJobPart.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut;
 
 import de.thomas_oster.liblasercut.platform.Point;

--- a/src/main/java/de/thomas_oster/liblasercut/TimeIntensiveOperation.java
+++ b/src/main/java/de/thomas_oster/liblasercut/TimeIntensiveOperation.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut;
 
 import java.util.LinkedList;

--- a/src/main/java/de/thomas_oster/liblasercut/VectorCommand.java
+++ b/src/main/java/de/thomas_oster/liblasercut/VectorCommand.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 /*
  * To change this template, choose Tools | Templates
  * and open the template in the editor.

--- a/src/main/java/de/thomas_oster/liblasercut/VectorPart.java
+++ b/src/main/java/de/thomas_oster/liblasercut/VectorPart.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut;
 
 import java.util.LinkedList;

--- a/src/main/java/de/thomas_oster/liblasercut/dithering/Average.java
+++ b/src/main/java/de/thomas_oster/liblasercut/dithering/Average.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.dithering;
 
 import de.thomas_oster.liblasercut.BlackWhiteRaster;

--- a/src/main/java/de/thomas_oster/liblasercut/dithering/BrightenedHalftone.java
+++ b/src/main/java/de/thomas_oster/liblasercut/dithering/BrightenedHalftone.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2016 Max Gaukler <development@maxgaukler.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2016 Max Gaukler <development@maxgaukler.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.dithering;
 
 

--- a/src/main/java/de/thomas_oster/liblasercut/dithering/DitheringAlgorithm.java
+++ b/src/main/java/de/thomas_oster/liblasercut/dithering/DitheringAlgorithm.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.dithering;
 
 import de.thomas_oster.liblasercut.BlackWhiteRaster;

--- a/src/main/java/de/thomas_oster/liblasercut/dithering/FloydSteinberg.java
+++ b/src/main/java/de/thomas_oster/liblasercut/dithering/FloydSteinberg.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.dithering;
 
 import de.thomas_oster.liblasercut.BlackWhiteRaster;

--- a/src/main/java/de/thomas_oster/liblasercut/dithering/Grid.java
+++ b/src/main/java/de/thomas_oster/liblasercut/dithering/Grid.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.dithering;
 
 import de.thomas_oster.liblasercut.BlackWhiteRaster;

--- a/src/main/java/de/thomas_oster/liblasercut/dithering/Halftone.java
+++ b/src/main/java/de/thomas_oster/liblasercut/dithering/Halftone.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2016 Max Gaukler <development@maxgaukler.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2016 Max Gaukler <development@maxgaukler.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 
 package de.thomas_oster.liblasercut.dithering;
 

--- a/src/main/java/de/thomas_oster/liblasercut/dithering/Ordered.java
+++ b/src/main/java/de/thomas_oster/liblasercut/dithering/Ordered.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.dithering;
 
 import de.thomas_oster.liblasercut.BlackWhiteRaster;

--- a/src/main/java/de/thomas_oster/liblasercut/dithering/Random.java
+++ b/src/main/java/de/thomas_oster/liblasercut/dithering/Random.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.dithering;
 
 import de.thomas_oster.liblasercut.BlackWhiteRaster;

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/Dummy.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/Dummy.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.drivers;
 
 import de.thomas_oster.liblasercut.*;

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/EpilogCutter.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/EpilogCutter.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 /*
  * Known Limitations:
  * - If there is Raster and Raster3d Part in one job, the speed from 3d raster

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/EpilogEngraveProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/EpilogEngraveProperty.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.drivers;
 
 import de.thomas_oster.liblasercut.PowerSpeedFocusProperty;

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/EpilogHelix.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/EpilogHelix.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 /*
   Known Limitations:
   - If there is Raster and Raster3d Part in one job, the speed from 3d raster

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/EpilogZing.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/EpilogZing.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 /*
   Known Limitations:
   - If there is Raster and Raster3d Part in one job, the speed from 3d raster

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/FloatPowerSpeedProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/FloatPowerSpeedProperty.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.drivers;
 
 import de.thomas_oster.liblasercut.LaserProperty;

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/FullSpectrumCutter.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/FullSpectrumCutter.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 
 package de.thomas_oster.liblasercut.drivers;
 

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/GenericGcodeDriver.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/GenericGcodeDriver.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.drivers;
 
 import de.thomas_oster.liblasercut.*;

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/GoldCutHPGL.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/GoldCutHPGL.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 /*
  * Copyright (C) 2015 Jürgen Weigert <juewei@fabfolk.com>
  */

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/Grbl.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/Grbl.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.drivers;
 
 import de.thomas_oster.liblasercut.ProgressListener;

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/IModelaMill.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/IModelaMill.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 
 package de.thomas_oster.liblasercut.drivers;
 

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/IModelaProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/IModelaProperty.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 
 package de.thomas_oster.liblasercut.drivers;
 

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/K40NanoDriver.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/K40NanoDriver.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 
 package de.thomas_oster.liblasercut.drivers;
 

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/LaosCutter.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/LaosCutter.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.drivers;
 
 import de.thomas_oster.liblasercut.ByteArrayList;

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/LaosCutterProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/LaosCutterProperty.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.drivers;
 
 import de.thomas_oster.liblasercut.FloatPowerSpeedFocusFrequencyProperty;

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/LaosEngraveProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/LaosEngraveProperty.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 
 package de.thomas_oster.liblasercut.drivers;
 

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/LaserToolsTechnicsCutter.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/LaserToolsTechnicsCutter.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.drivers;
 
 import de.thomas_oster.liblasercut.ByteArrayList;

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/Lasersaur.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/Lasersaur.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.drivers;
 
 import de.thomas_oster.liblasercut.*;

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/MakeBlockXYPlotter.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/MakeBlockXYPlotter.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 
 /*
   Author: Sven Jung <sven.jung@rwth-aachen.de>

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/MakeBlockXYPlotterProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/MakeBlockXYPlotterProperty.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 
 /*
   Author: Sven Jung <sven.jung@rwth-aachen.de>

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/Marlin.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/Marlin.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.drivers;
 
 import de.thomas_oster.liblasercut.ProgressListener;

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/SampleDriver.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/SampleDriver.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 
 package de.thomas_oster.liblasercut.drivers;
 

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/SmoothieBoard.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/SmoothieBoard.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.drivers;
 
 import java.io.IOException;

--- a/src/main/java/de/thomas_oster/liblasercut/examples/PhotoPrint.java
+++ b/src/main/java/de/thomas_oster/liblasercut/examples/PhotoPrint.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.examples;
 
 import de.thomas_oster.liblasercut.BlackWhiteRaster;

--- a/src/main/java/de/thomas_oster/liblasercut/laserscript/ScriptInterface.java
+++ b/src/main/java/de/thomas_oster/liblasercut/laserscript/ScriptInterface.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.laserscript;
 
 /**

--- a/src/main/java/de/thomas_oster/liblasercut/laserscript/ScriptInterpreter.java
+++ b/src/main/java/de/thomas_oster/liblasercut/laserscript/ScriptInterpreter.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.laserscript;
 
 import java.io.IOException;

--- a/src/main/java/de/thomas_oster/liblasercut/laserscript/ScriptingSecurity.java
+++ b/src/main/java/de/thomas_oster/liblasercut/laserscript/ScriptingSecurity.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.laserscript;
 
 import org.mozilla.javascript.ClassShutter;

--- a/src/main/java/de/thomas_oster/liblasercut/laserscript/VectorPartScriptInterface.java
+++ b/src/main/java/de/thomas_oster/liblasercut/laserscript/VectorPartScriptInterface.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.laserscript;
 
 import de.thomas_oster.liblasercut.LaserProperty;

--- a/src/main/java/de/thomas_oster/liblasercut/platform/Circle.java
+++ b/src/main/java/de/thomas_oster/liblasercut/platform/Circle.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2019 Max Gaukler <development@maxgaukler.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2019 Max Gaukler <development@maxgaukler.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.platform;
 
 import java.util.List;

--- a/src/main/java/de/thomas_oster/liblasercut/platform/Point.java
+++ b/src/main/java/de/thomas_oster/liblasercut/platform/Point.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.platform;
 
 /**

--- a/src/main/java/de/thomas_oster/liblasercut/platform/Rectangle.java
+++ b/src/main/java/de/thomas_oster/liblasercut/platform/Rectangle.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.platform;
 
 /**

--- a/src/main/java/de/thomas_oster/liblasercut/platform/Tuple.java
+++ b/src/main/java/de/thomas_oster/liblasercut/platform/Tuple.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 /*
  * To change this template, choose Tools | Templates
  * and open the template in the editor.

--- a/src/main/java/de/thomas_oster/liblasercut/platform/Util.java
+++ b/src/main/java/de/thomas_oster/liblasercut/platform/Util.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 /*
  * To change this template, choose Tools | Templates
  * and open the template in the editor.

--- a/src/main/java/de/thomas_oster/liblasercut/utils/BufferedImageAdapter.java
+++ b/src/main/java/de/thomas_oster/liblasercut/utils/BufferedImageAdapter.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 /*
  * To change this template, choose Tools | Templates
  * and open the template in the editor.

--- a/src/main/java/de/thomas_oster/liblasercut/utils/ShapeConverter.java
+++ b/src/main/java/de/thomas_oster/liblasercut/utils/ShapeConverter.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.utils;
 
 import de.thomas_oster.liblasercut.LaserCutter;

--- a/src/main/java/de/thomas_oster/liblasercut/utils/ShapeRecognizer.java
+++ b/src/main/java/de/thomas_oster/liblasercut/utils/ShapeRecognizer.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 /*
  * To change this template, choose Tools | Templates
  * and open the template in the editor.

--- a/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/DeleteDuplicatePathsOptimizer.java
+++ b/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/DeleteDuplicatePathsOptimizer.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.vectoroptimizers;
 
 import java.util.LinkedList;

--- a/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/FileVectorOptimizer.java
+++ b/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/FileVectorOptimizer.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.vectoroptimizers;
 
 import de.thomas_oster.liblasercut.VectorPart;

--- a/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/InnerFirstVectorOptimizer.java
+++ b/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/InnerFirstVectorOptimizer.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.vectoroptimizers;
 
 import java.util.Collections;

--- a/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/NearestVectorOptimizer.java
+++ b/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/NearestVectorOptimizer.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.vectoroptimizers;
 
 import de.thomas_oster.liblasercut.platform.Point;

--- a/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/OptimizerUtils.java
+++ b/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/OptimizerUtils.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.vectoroptimizers;
 
 import de.thomas_oster.liblasercut.LaserProperty;

--- a/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/SmallestFirstVectorOptimizer.java
+++ b/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/SmallestFirstVectorOptimizer.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.vectoroptimizers;
 
 import java.util.Collections;

--- a/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/VectorOptimizer.java
+++ b/src/main/java/de/thomas_oster/liblasercut/vectoroptimizers/VectorOptimizer.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.vectoroptimizers;
 
 import de.thomas_oster.liblasercut.LaserProperty;

--- a/src/test/java/de/thomas_oster/liblasercut/BlackWhiteRasterTest.java
+++ b/src/test/java/de/thomas_oster/liblasercut/BlackWhiteRasterTest.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 /*
  * To change this template, choose Tools | Templates
  * and open the template in the editor.

--- a/src/test/java/de/thomas_oster/liblasercut/RasterizableJobPartTest.java
+++ b/src/test/java/de/thomas_oster/liblasercut/RasterizableJobPartTest.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut;
 
 import de.thomas_oster.liblasercut.platform.Point;

--- a/src/test/java/de/thomas_oster/liblasercut/drivers/AllDriversTest.java
+++ b/src/test/java/de/thomas_oster/liblasercut/drivers/AllDriversTest.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2020 Max Gaukler (development@maxgaukler.de)
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2020 Max Gaukler (development@maxgaukler.de)
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.drivers;
 
 import de.thomas_oster.liblasercut.GreyRaster;
@@ -64,8 +64,8 @@ public class AllDriversTest {
   
   /**
    * filename for storing the test output
-   * @param class Class of lasercutter driver
-   * @param new True: temporary file for storing the new results / False: "old" file with known-good result
+   * @param c Class of lasercutter driver
+   * @param isNew temporary file for storing the new results / False: "old" file with known-good result
   */
   private String getOutputFilename(Class c, boolean isNew)
   {

--- a/src/test/java/de/thomas_oster/liblasercut/drivers/LaosCutterTest.java
+++ b/src/test/java/de/thomas_oster/liblasercut/drivers/LaosCutterTest.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.drivers;
 
 import de.thomas_oster.liblasercut.LaserJob;

--- a/src/test/java/de/thomas_oster/liblasercut/drivers/LaserCutterTest.java
+++ b/src/test/java/de/thomas_oster/liblasercut/drivers/LaserCutterTest.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2020 Max Gaukler (development@maxgaukler.de)
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2020 Max Gaukler (development@maxgaukler.de)
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.drivers;
 
 import de.thomas_oster.liblasercut.GreyRaster;

--- a/src/test/java/de/thomas_oster/liblasercut/laserscript/ScriptInterpreterTest.java
+++ b/src/test/java/de/thomas_oster/liblasercut/laserscript/ScriptInterpreterTest.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.laserscript;
 
 import de.thomas_oster.liblasercut.PowerSpeedFocusProperty;

--- a/src/test/java/de/thomas_oster/liblasercut/vectoroptimizers/InnerFirstVectorOptimizerTest.java
+++ b/src/test/java/de/thomas_oster/liblasercut/vectoroptimizers/InnerFirstVectorOptimizerTest.java
@@ -1,21 +1,21 @@
-/**
- * This file is part of LibLaserCut.
- * Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
- *
- * LibLaserCut is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * LibLaserCut is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
- *
- **/
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2011 - 2014 Thomas Oster <mail@thomas-oster.de>
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
 package de.thomas_oster.liblasercut.vectoroptimizers;
 
 import de.thomas_oster.liblasercut.PowerSpeedFocusProperty;

--- a/test.sh
+++ b/test.sh
@@ -11,7 +11,7 @@ fi
 # filter out the lines that are not relevant for the license
 #  - author lines: that contain year, author name(s) and at least one email adress enclosed in <> or ()
 #  - blank lines: just " *" or similar
-IGNORE_AUTHOR_LINE_REGEXP='^([ \*]*| \* Copyright \([cC]\) 20[0-9]{2}.*[<\(].*@.*[>\)].*)$'
+IGNORE_AUTHOR_LINE_REGEXP='^(  Copyright \([cC]\) 20[0-9]{2}.*[<\(].*@.*[>\)].*)$'
 
 HEADERSIZE=$(cat copyrightheader | egrep -v "$IGNORE_AUTHOR_LINE_REGEXP" | wc -l)
 ERRORS=0


### PR DESCRIPTION
Having Javadoc at the beginning of a .java file is an error. I converted these into block comments.