### PR TITLE
Character Counting Support

### DIFF
--- a/src/main/java/de/thomas_oster/liblasercut/drivers/GenericGcodeDriver.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/GenericGcodeDriver.java
@@ -545,7 +545,7 @@ public class GenericGcodeDriver extends LaserCutter {
     bufferedSend += length;
     if (commandLengthQueue != null)
     {
-      commandLengthQueue.add(data.length());
+      commandLengthQueue.add(length);
     }
   }
   


### PR DESCRIPTION
Modifies the GenericGcodeDriver to permit character counting.

* `sendLine()` is broken into `formatLine()`, `sendData()` and `waitForOK()`.
* The formatLine() code merely formats the line in the way it was formatted in the sendLine() previously.
* The `sendData()` function adds functionality to add the sent line length to `bufferedSend`.
* The `sendData()` function adds functionality to add the sent line length to the `commandLengthQueue`.
* The `waitForOK()` function consists of the original code found in `sendLine()` function, but also removes the head of the `commandLengthQueue` and decrements that from the `bufferedSend`.

This should be testable for the original unaltered functionality of `GenericGcodeDriver.java`.

---

Phase 2.

The only function that overloads `sendLine()` is found in `Grbl.java` and consists of the same functionality as the original code. Except that the `text` string has the spaces removed: `text.replace(" ", "")`

In phase 2, this would be replaced with a different sendLine() which would can be permitted to implement character counting. 

The `formatLine()` function will be overloaded to include the modification seen in the GRBL driver.

```java
  protected String formatLine(String text, Object... parameters) {
    return String.format(FORMAT_LOCALE, text.replace(" ", "")+LINEEND(), parameters);
  }
```

And the `sendLine()` function will be modified to character count:

```java
  protected void sendLine(String text, Object... parameters) throws IOException
  {
    String line = formatLine(text, parameters);
    int length = line.length();
    while (bufferedSend + length < 128)
    {
      waitForOK();
    }
    sendData(line);
  }
```
