### PR TITLE
t-oster/VisiCut#577 Return 0,0, not Home

### DIFF
--- a/src/main/java/de/thomas_oster/liblasercut/drivers/K40NanoDriver.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/K40NanoDriver.java
@@ -264,6 +264,7 @@ public class K40NanoDriver extends LaserCutter
         }
       }
     }
+    device.exit_compact_mode();
     device.move_absolute(0, 0); //Return device to start position 0,0.
     device.execute();
     device.close();

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/K40NanoDriver.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/K40NanoDriver.java
@@ -264,7 +264,7 @@ public class K40NanoDriver extends LaserCutter
         }
       }
     }
-    device.home(); //Home the device after the job.
+    device.move_absolute(0, 0); //Return device to start position 0,0.
     device.execute();
     device.close();
   }

--- a/test-output/de.thomas_oster.liblasercut.drivers.K40NanoDriver.out
+++ b/test-output/de.thomas_oster.liblasercut.drivers.K40NanoDriver.out
@@ -28,7 +28,6 @@ TUTn
 DTb
 BBp
 TTl
+ULaMaLbMaLaMaLbMaLbMaLbMaLbMaLaMaLbMaLbMaLbMaLbMaLaMaLbMaLbMaLbMaLbMaLaMaLbMaLbMaLbMaLbMaLaMaLbMaLbMaLbMaLbMaLaMaLbMaLbMaLa
 FNSE-
-
-IPP
 

--- a/test-output/de.thomas_oster.liblasercut.drivers.K40NanoDriver.out
+++ b/test-output/de.thomas_oster.liblasercut.drivers.K40NanoDriver.out
@@ -28,6 +28,7 @@ TUTn
 DTb
 BBp
 TTl
-ULaMaLbMaLaMaLbMaLbMaLbMaLbMaLaMaLbMaLbMaLbMaLbMaLaMaLbMaLbMaLbMaLbMaLaMaLbMaLbMaLbMaLbMaLaMaLbMaLbMaLbMaLbMaLaMaLbMaLbMaLa
 FNSE-
+
+IT|eL084S1P
 


### PR DESCRIPTION
Correction for t-oster/VisiCut#577 rather than home returning to true 0,0 we return simply absolute move to 0,0 so if we began this operation at an adjusted position, we maintain that adjustment rather than lose it for subsequent operations.