### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,7 @@ script:
   # Note: Due to a design defect, this cannot test code coverage of new pull requests!
   # Codacy require a private API key that is passed as Travis-CI environment variable. For security reasons, this variable is unavailable on external pull requests.
   - 'if [ -n "$CODACY_PROJECT_TOKEN" ]; then echo "Uploading coverage to codacy"; bash <(curl -Ls https://coverage.codacy.com/get.sh); fi'
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
