### PR TITLE
Calibrate Epilog Helix constants for `estimateJobDuration`

### DIFF
--- a/src/main/java/de/thomas_oster/liblasercut/drivers/EpilogCutter.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/EpilogCutter.java
@@ -964,22 +964,6 @@ abstract class EpilogCutter extends LaserCutter
     return true;
   }
 
-  @Override
-  public int estimateJobDuration(LaserJob job)
-  {
-    // It's not entirely clear how these values were determined. They are probably calibrated for the Epilog Zing.
-    double PX2MM_500DPI = Util.px2mm(1, 500);
-    double VECTOR_MOVESPEED_X = PX2MM_500DPI * 20000d / 4.5;
-    double VECTOR_MOVESPEED_Y = PX2MM_500DPI * 10000d / 2.5;
-    double VECTOR_LINESPEED = PX2MM_500DPI * 20000d / 36.8;
-    double RASTER_LINEOFFSET = 0.08d;
-    double RASTER_LINESPEED = PX2MM_500DPI * 100000d / ((268d / 50) - RASTER_LINEOFFSET);
-    //TODO: The Raster3d values are not tested yet, theyre just copies
-    double RASTER3D_LINEOFFSET = RASTER_LINEOFFSET;
-    double RASTER3D_LINESPEED = RASTER_LINESPEED;
-    
-    return estimateJobDuration(job, VECTOR_MOVESPEED_X, VECTOR_MOVESPEED_Y, VECTOR_LINESPEED, RASTER_LINEOFFSET, RASTER_LINESPEED, RASTER3D_LINEOFFSET, RASTER3D_LINESPEED);
-  }
 
   @Override
   public void saveJob(OutputStream fileOutputStream, LaserJob job) throws UnsupportedOperationException, IllegalJobException, Exception {

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/EpilogHelix.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/EpilogHelix.java
@@ -25,6 +25,8 @@
 
 package de.thomas_oster.liblasercut.drivers;
 
+import de.thomas_oster.liblasercut.LaserJob;
+import de.thomas_oster.liblasercut.platform.Util;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -34,27 +36,34 @@ import java.util.List;
  */
 public class EpilogHelix extends EpilogCutter
 {
-  
+  // Calibrated by Seth Troisi on Epilog Helix circa August 2023.
+  // Movement speed in millimeters / second.
+  protected final double VECTOR_MOVESPEED_X = 163d;
+  protected final double VECTOR_MOVESPEED_Y = 163d;
+
+  // Cut Speed in millimeters / second.
+  protected final double VECTOR_LINESPEED = 21.3d;
+
+
   public EpilogHelix()
   {
   }
-  
+
   public EpilogHelix(String hostname)
   {
     super(hostname);
   }
-  
   @Override
   public String getModelName()
   {
     return "Epilog Helix";
   }
-  
+
   private static final double[] RESOLUTIONS = new double[]
   {
      75, 150, 200, 300, 400, 600, 1200
   };
-  
+
   @Override
   public List<Double> getResolutions()
   {
@@ -65,7 +74,7 @@ public class EpilogHelix extends EpilogCutter
     }
     return result;
   }
-  
+
   @Override
   public EpilogHelix clone()
   {
@@ -145,5 +154,20 @@ public class EpilogHelix extends EpilogCutter
   public void setHideSoftwareFocus(boolean b)
   {
     super.setHideSoftwareFocus(b);
+  }
+
+  @Override
+  public int estimateJobDuration(LaserJob job)
+  {
+    // TODO: Calibrate these RASTER settings.
+    double PX2MM_500DPI = Util.px2mm(1, 500);
+    // Extra time (in millis) per raster line.
+    double RASTER_LINEOFFSET = 0.08d;
+    double RASTER_LINESPEED = PX2MM_500DPI * 100000d / ((268d / 50) - RASTER_LINEOFFSET);
+    //TODO: The Raster3d values are not tested yet, they're copied from old EpilogCutter.
+    double RASTER3D_LINEOFFSET = RASTER_LINEOFFSET;
+    double RASTER3D_LINESPEED = RASTER_LINESPEED;
+
+    return estimateJobDuration(job, VECTOR_MOVESPEED_X, VECTOR_MOVESPEED_Y, VECTOR_LINESPEED, RASTER_LINEOFFSET, RASTER_LINESPEED, RASTER3D_LINEOFFSET, RASTER3D_LINESPEED);
   }
 }

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/EpilogZing.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/EpilogZing.java
@@ -25,6 +25,8 @@
 
 package de.thomas_oster.liblasercut.drivers;
 
+import de.thomas_oster.liblasercut.LaserJob;
+import de.thomas_oster.liblasercut.platform.Util;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -49,7 +51,7 @@ public class EpilogZing extends EpilogCutter
   {
     return "Epilog ZING";
   }
-  
+
   private static final double[] RESOLUTIONS = new double[]
   {
     100, 200, 250, 400, 500, 1000
@@ -145,5 +147,25 @@ public class EpilogZing extends EpilogCutter
   public void setHideSoftwareFocus(boolean b)
   {
     super.setHideSoftwareFocus(b);
+  }
+
+  @Override
+  public int estimateJobDuration(LaserJob job)
+  {
+    // It's not entirely clear how these values were determined. They are probably calibrated for the Epilog Zing.
+    double PX2MM_500DPI = Util.px2mm(1, 500);
+    // millimeters / second
+    double VECTOR_MOVESPEED_X = PX2MM_500DPI * 20000d / 4.5;
+    double VECTOR_MOVESPEED_Y = PX2MM_500DPI * 10000d / 2.5;
+    double VECTOR_LINESPEED = PX2MM_500DPI * 20000d / 36.8;
+
+    // Extra time (in millis) per raster line.
+    double RASTER_LINEOFFSET = 0.08d;
+    double RASTER_LINESPEED = PX2MM_500DPI * 100000d / ((268d / 50) - RASTER_LINEOFFSET);
+    //TODO: The Raster3d values are not tested yet, they're just copies
+    double RASTER3D_LINEOFFSET = RASTER_LINEOFFSET;
+    double RASTER3D_LINESPEED = RASTER_LINESPEED;
+
+    return estimateJobDuration(job, VECTOR_MOVESPEED_X, VECTOR_MOVESPEED_Y, VECTOR_LINESPEED, RASTER_LINEOFFSET, RASTER_LINESPEED, RASTER3D_LINEOFFSET, RASTER3D_LINESPEED);
   }
 }

--- a/src/test/java/de/thomas_oster/liblasercut/drivers/EpilogHelixCutterTest.java
+++ b/src/test/java/de/thomas_oster/liblasercut/drivers/EpilogHelixCutterTest.java
@@ -1,0 +1,80 @@
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2023
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
+package de.thomas_oster.liblasercut.drivers;
+
+import de.thomas_oster.liblasercut.*;
+import de.thomas_oster.liblasercut.platform.Point;
+import de.thomas_oster.liblasercut.platform.Util;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+public class EpilogHelixCutterTest extends EpilogHelix
+{
+  // estimate time is truncated to int
+  final double DELTA = 1.0;
+  @Test
+  public void testHostName()
+  {
+    String hostname = "FooBar";
+    EpilogHelix helix = new EpilogHelix(hostname);
+    assertEquals(hostname, helix.getHostname());
+  }
+  @Test
+  public void testEstimateDuration()
+  {
+    // Resolution such that 42px = 1mm
+    double mm2px = 42;
+    double dpi = Util.dpmm2dpi(mm2px);
+
+    for (int speedPercent : Arrays.asList(5, 17, 100)) {
+      LaserProperty prop = getLaserPropertyForVectorPart();
+      prop.setProperty("speed", speedPercent);
+
+      double expectedTime = 0;
+      LaserJob job = new LaserJob("", "", "");
+
+      System.out.println(speedPercent);
+
+      // 1. Move mainly in x -> time == dx / move_speed_x (always at full speed).
+      VectorPart p = new VectorPart(prop, dpi);
+      p.moveto(1000 * mm2px, 1 * mm2px);
+      job.addPart(p);
+      expectedTime += 1000 / this.VECTOR_MOVESPEED_X;
+      assertEquals(expectedTime, this.estimateJobDuration(job), DELTA);
+
+      // 2. Move mainly in y -> time == dy / move_speed_y (always at full speed).
+      p.moveto(1000 * mm2px, 1001 * mm2px);
+      expectedTime += 1000 / this.VECTOR_MOVESPEED_Y;
+      assertEquals(expectedTime, this.estimateJobDuration(job), DELTA);
+
+      // 3. Cut line at speedPercent.
+      p.lineto(1500 * mm2px, 1701 * mm2px);
+      expectedTime += Math.hypot(500, 700) / this.VECTOR_LINESPEED * 100.0 / speedPercent;
+      assertEquals(expectedTime, this.estimateJobDuration(job), DELTA);
+
+      // 4. Engrave.
+      // Not yet calibrated
+
+      // Raster3dPart is not explicitly tested, it uses almost the same codepath as RasterPart.
+    }
+  }
+}

--- a/src/test/java/de/thomas_oster/liblasercut/drivers/EpilogZingCutterTest.java
+++ b/src/test/java/de/thomas_oster/liblasercut/drivers/EpilogZingCutterTest.java
@@ -1,0 +1,86 @@
+/*
+  This file is part of LibLaserCut.
+  Copyright (C) 2023
+
+  LibLaserCut is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  LibLaserCut is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
+
+ */
+package de.thomas_oster.liblasercut.drivers;
+
+import static org.junit.Assert.assertEquals;
+
+import de.thomas_oster.liblasercut.LaserJob;
+import de.thomas_oster.liblasercut.LaserProperty;
+import de.thomas_oster.liblasercut.VectorPart;
+import de.thomas_oster.liblasercut.platform.Util;
+import java.util.Arrays;
+import org.junit.Test;
+
+public class EpilogZingCutterTest extends EpilogZing
+{
+  // estimate time is truncated to int
+  final double DELTA = 1.0;
+
+  /** millimeters/second */
+  final double MOVE_SPEED_X =  225.7;
+  final double MOVE_SPEED_Y = 203.2;
+
+  final double CUT_SPEED = 27.61;
+  @Test
+  public void testHostName()
+  {
+    String hostname = "FooBar";
+    EpilogZing zing = new EpilogZing(hostname);
+    assertEquals(hostname, zing.getHostname());
+  }
+  @Test
+  public void testEstimateDuration()
+  {
+    // Resolution such that 42px = 1mm
+    double mm2px = 42;
+    double dpi = Util.dpmm2dpi(mm2px);
+
+    for (int speedPercent : Arrays.asList(5, 17, 100)) {
+      LaserProperty prop = getLaserPropertyForVectorPart();
+      prop.setProperty("speed", speedPercent);
+
+      double expectedTime = 0;
+      LaserJob job = new LaserJob("", "", "");
+
+      System.out.println(speedPercent);
+
+      // 1. Move mainly in x -> time == dx / move_speed_x (always at full speed).
+      VectorPart p = new VectorPart(prop, dpi);
+      p.moveto(1000 * mm2px, 1 * mm2px);
+      job.addPart(p);
+      expectedTime += 1000 / MOVE_SPEED_X;
+      assertEquals(expectedTime, this.estimateJobDuration(job), DELTA);
+
+      // 2. Move mainly in y -> time == dy / move_speed_y (always at full speed).
+      p.moveto(1000 * mm2px, 1001 * mm2px);
+      expectedTime += 1000 / MOVE_SPEED_Y;
+      assertEquals(expectedTime, this.estimateJobDuration(job), DELTA);
+
+      // 3. Cut line at speedPercent.
+      p.lineto(1500 * mm2px, 1701 * mm2px);
+      expectedTime += Math.hypot(500, 700) / CUT_SPEED * 100.0 / speedPercent;
+      assertEquals(expectedTime, this.estimateJobDuration(job), DELTA);
+
+      // 4. Engrave.
+      // Not yet calibrated
+
+      // Raster3dPart is not explicitly tested, it uses almost the same codepath as RasterPart.
+    }
+  }
+}


### PR DESCRIPTION
I took 22 measurements with my Epilog Helix Mini doing cuts at several angles and moving in several angles and got very similar speeds. These are roughly 25% slower than the existing numbers.

I added some tests for both EpilogHelix and EpilogZing.

I also ran and tested this change in VisiCut (though my java setup in intellij is incomplete and failed to loading some of the XML but that's a different issue)

![Screenshot from 2023-08-31 15-13-31](https://github.com/t-oster/LibLaserCut/assets/10172976/5f4dc984-2717-4683-b198-be527837c9d2)
