### PR TITLE
Fix old SOREUSEADDR problem.

### DIFF
--- a/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
@@ -56,6 +56,7 @@ import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
+import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -529,8 +530,11 @@ public class Ruida extends LaserCutter
       writeJobCode(job, pl);
     }
     catch (IOException e) {
+      System.out.println("SendJob IOException " + e);
       pl.taskChanged(this, "disconnecting");
+      System.out.println("sendJob disconnect ...");
       disconnect();
+      System.out.println("sendJob disconnect done");
       throw e;
     }
     disconnect();
@@ -1158,7 +1162,9 @@ class UdpStream extends OutputStream
     this.port = DEST_PORT;
 //    System.out.println("UdpStream(" + hostname + ", " + port + ")");
     try {
-      socket = new DatagramSocket(SOURCE_PORT);
+      socket = new DatagramSocket(null);
+      socket.setReuseAddress(true); 	// allow to retry, after failure
+      socket.bind(new InetSocketAddress(SOURCE_PORT));
       socket.setSoTimeout(NETWORK_TIMEOUT);
       address = InetAddress.getByName(hostname);
     }
@@ -1215,6 +1221,7 @@ class UdpStream extends OutputStream
       socket.receive(receivePacket);
     }
     catch (SocketTimeoutException e) {
+      System.out.println("IOException: UdpStream.send Response timeout in UdpStream");
       throw new IOException("Response timeout in UdpStream");
     }
     int l = receivePacket.getLength();


### PR DESCRIPTION
After a any type of network error, a DatagramSocket() that was already bound to a SOURCE_PORT can never be re-opened. Impact: User sends a job before laser is ready to accept -> then visicut says "bind error: already in use" -> user must quit and restart visicut.

With this fix, the user can try to send again, and visicut actually sends again (instead of immediately bailing out with a pointless "already in use" error.)