### PR TITLE
Re-Raise the IOException after it got lost in java PrintStream

### DIFF
--- a/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
@@ -496,6 +496,15 @@ public class Ruida extends LaserCutter
       in.close();
     }
     out.close();
+    if (out.checkError())
+    {
+      /**
+       * https://docs.oracle.com/javase/8/docs/api/java/io/PrintStream.html says:
+       * "Unlike other output streams, a PrintStream never throws an IOException; instead, exceptional
+       *  situations merely set an internal flag that can be tested via the checkError method."
+       */
+      throw new IOException("disconnect: send failed.");
+    }
     if (this.port != null)
     {
       this.port.close();


### PR DESCRIPTION
Closes #193 
 
Java is too intelligent.
The exception message gets lost, we only have one bit. 
So there is nothing useful we can tell the user. I'll leave the println in, so that at least console has something more useful.