### PR TITLE
Ruida: various driver bug fixes and improvments

### DIFF
--- a/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
@@ -1066,7 +1066,7 @@ class ByteStream
    * append relative value
    */
   public ByteStream relative(double d, boolean signed) throws IOException {
-    int val = (int)Math.floor(d);
+    int val = (int)Math.round(d);
 //    System.out.println("rel" + ((signed)?"Signed":"Unsigned") + "ValueToByteArray(" + d + " -> " + val + ")");
     if (signed) {
       if (val > 8191) {

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
@@ -668,6 +668,13 @@ public class Ruida extends LaserCutter
           }
         }
       }
+
+      part_number++;
+      first_prop = true;
+      first_vector = true;
+      currentMinPower = -1;
+      currentMaxPower = -1;
+      currentSpeed = -1;
     }
 
     /* work interval */

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
@@ -643,7 +643,7 @@ public class Ruida extends LaserCutter
                 currentMinPower = cmd_layer_percent("c631", part_number, currentMinPower, prop.getMinPower());
                 currentMaxPower = cmd_layer_percent("c632", part_number, currentMaxPower, prop.getPower());
                   // prop speed is in %, ruida speed is in mm/s (0..1000)
-                currentSpeed = cmd_layer_absoluteMM("c904", part_number, currentSpeed, prop.getSpeed() * 10);
+                currentSpeed = cmd_layer_absoluteMM("c904", part_number, currentSpeed, prop.getSpeed() * getMaxVectorCutSpeed() / 100);
                 // focus - n/a
                 // frequency
                 stream.hex("c660").byteint(part_number).hex("00").longint(prop.getFrequency());
@@ -657,7 +657,7 @@ public class Ruida extends LaserCutter
                 currentMinPower = cmd_percent("c601", currentMinPower, prop.getMinPower());
                 currentMaxPower = cmd_percent("c602", currentMaxPower, prop.getPower());
                   // prop speed is in %, ruida speed is in mm/s (0..1000)
-                currentSpeed = cmd_absoluteMM("c902", currentSpeed, prop.getSpeed() * 10);
+                currentSpeed = cmd_absoluteMM("c902", currentSpeed, prop.getSpeed() * getMaxVectorCutSpeed() / 100);
               }
               break;
             }

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
@@ -549,6 +549,8 @@ public class Ruida extends LaserCutter
   public void writeJobCode(LaserJob job, ProgressListener pl) throws IOException {
     last_x = Double.NaN;
     last_y = Double.NaN;
+    vector_count = 0;
+    travel_distance = 0;
 
     try {
       stream = new ByteStream(out, (byte)0x88); // 0x11, 0x38

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
@@ -622,7 +622,7 @@ public class Ruida extends LaserCutter
                 stream.hex("ca01").byteint(engrave ? 1 : 0); // processing mode (00: cut, 01: bidirectional x-sweep, 02: unidirectional x-sweep)
                 stream.hex("ca02").byteint(part_number); // start_layer
                 stream.hex("ca0113"); // blow on
-                stream.hex("c902").longint((int)currentSpeed);
+                stream.hex("c902").absoluteMM((int)currentSpeed);
                 // power for laser #1
                 stream.hex("c601").percent((int)currentMinPower);
                 stream.hex("c602").percent((int)currentMaxPower);

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
@@ -672,8 +672,6 @@ public class Ruida extends LaserCutter
 
     /* work interval */
     stream.hex("DA010620").longint(travel_distance).longint(travel_distance);
-    /* finish */
-    stream.hex("EB");
     /* stop */
     stream.hex("E700");
     /* eof */

--- a/test-output/de.thomas_oster.liblasercut.drivers.Ruida.out
+++ b/test-output/de.thomas_oster.liblasercut.drivers.Ruida.out
@@ -1,1 +1,1 @@
-Ò›úâ‹p	ým{ý‰z‹‰Ò‰p‰‰‰‰‰‰‰‰‰‰p‰‰‰õ‰‰‰‰‰p‰‰é‰‰…ùpÙ‰‰‰õ‰‰‰‰‰pY‰‰é‰‰…ùp‰	‰	‰‰‰‰‰‰‰‰‰‰p‰Ä«‹pÛ‰‰‰‰õ‰‰‰‰‰p[‰‰‰é‰‰…ùpi‰‰‰‰õ‰‰‰‰‰pë‰‰‰é‰‰…ùÐ9‰‰‰Ð»‰‰‰B‰‰‰5ÉÐé‰‰‰‰‰ýÄ‰‰‰‰‰íÄI‰‰Ä	‰Ä‹‰Ä	B‹‰‰5ÉÐ	‰‰Ð‹‰‰ÄÄ™‰‚‰‰‰õ‰‰‰õ¢‰‰	Ï±‰‰…ù¢‰‰…ù‰‰‰‰‰‚‰‰é‰‰‰‰‰¢‰‰[/‰‰‰/Ñ¢‰‰Û}‰‰	—é"‰û"w?m"‰»/_¢‰‰[/‰‰‹m‘¢‰‰é‰‰…ùpÛ‰‰‰‰‰‰‰‡_p[‰‰‰‰U‰‰‰™]pi‰‰‰‰‰‰‰‡_pë‰‰‰‰U‰‰‰™]‚‰‰‰‰‰‰‡_¢‰‰‰q‰‰‰‡_¢‰‰‰W‰‰‰‡_¢‰‰‰›‰‰‰‡_¢‰‰‰£‰‰‰‡_¢‰‰‰U‰‰‰‡_‚‰‰‰U‰‰‰ƒ¢‰‰‰£‰‰‰ƒ¢‰‰‰M‰‰‰ƒ¢‰‰‰W‰‰‰ƒ¢‰‰‰¥‰‰‰ƒ¢‰‰‰‰‰‰ƒ‚‰‰‰‰‰‰5¢‰‰‰U‰‰‰5‚‰‰‰U‰‰‰ù¢‰‰‰q‰‰‰ù¢‰‰‰‰‰‰ù‚‰‰‰‰‰‰™«¢‰‰‰U‰‰‰™«‚‰‰‰U‰‰‰™]¢‰‰‰q‰‰‰™]¢‰‰‰‰‰‰™]pÛ‰‰‰‰™]‰‰‰—Op[‰‰‰‰—‰‰‰©Mpi‰‰‰‰™]‰‰‰—Opë‰‰‰‰—‰‰‰©M‚‰‰‰3‰‰‰—O¢‰‰‰›©‰‰‰—O‚‰‰‰›[‰‰‰—O¢‰‰‰å‰‰‰—O‚‰‰‰å‰‰‰—ó¢‰‰‰‰‰‰—ó‚‰‰‰›©‰‰‰—ó¢‰‰‰e‰‰‰—ó‚‰‰‰™]‰‰‰%¢‰‰‰‰‰‰%‚‰‰‰3‰‰‰%¢‰‰‰—‰‰‰%‚‰‰‰—‰‰‰é¢‰‰‰3‰‰‰é‚‰‰‰™]‰‰‰©M¢‰‰‰3‰‰‰©MÔ	©‰‰‰‹e‰‰‰‹edp‰`
+Ò›úâ‹p	ým{ý‰z‹‰Ò‰p‰‰‰‰‰‰‰‰‰‰p‰‰‰õ‰‰‰‰‰p‰‰é‰‰…ùpÙ‰‰‰õ‰‰‰‰‰pY‰‰é‰‰…ùp‰	‰	‰‰‰‰‰‰‰‰‰‰p‰Ä«‹pÛ‰‰‰‰õ‰‰‰‰‰p[‰‰‰é‰‰…ùpi‰‰‰‰õ‰‰‰‰‰pë‰‰‰é‰‰…ùÐ9‰‰‰Ð»‰‰‰B‰‰‰5ÉÐé‰‰‰‰‰ýÄ‰‰‰‰‰íÄI‰‰Ä	‰Ä‹‰Ä	B‹‰‰5ÉÐ	‰‰Ð‹‰‰ÄÄ™‰‚‰‰‰õ‰‰‰õ¢‰‰	Ï±‰‰…ù¢‰‰…ù‰‰‰‰‰‚‰‰é‰‰‰‰‰¢‰‰[/‰‰‰/Ñ¢‰‰Û}‰‰	—é"‰{"w±m"‰;/Ñ¢‰‰[/‰‰‹m‘¢‰‰é‰‰…ùpÛ‰‰‰‰‰‰‰‡_p[‰‰‰‰U‰‰‰™]pi‰‰‰‰‰‰‰‡_pë‰‰‰‰U‰‰‰™]‚‰‰‰‰‰‰‡_¢‰‰‰q‰‰‰‡_¢‰‰‰W‰‰‰‡_¢‰‰‰›‰‰‰‡_¢‰‰‰£‰‰‰‡_¢‰‰‰U‰‰‰‡_‚‰‰‰U‰‰‰ƒ¢‰‰‰£‰‰‰ƒ¢‰‰‰M‰‰‰ƒ¢‰‰‰W‰‰‰ƒ¢‰‰‰¥‰‰‰ƒ¢‰‰‰‰‰‰ƒ‚‰‰‰‰‰‰5¢‰‰‰U‰‰‰5‚‰‰‰U‰‰‰ù¢‰‰‰q‰‰‰ù¢‰‰‰‰‰‰ù‚‰‰‰‰‰‰™«¢‰‰‰U‰‰‰™«‚‰‰‰U‰‰‰™]¢‰‰‰q‰‰‰™]¢‰‰‰‰‰‰™]pÛ‰‰‰‰™]‰‰‰—Op[‰‰‰‰—‰‰‰©Mpi‰‰‰‰™]‰‰‰—Opë‰‰‰‰—‰‰‰©M‚‰‰‰3‰‰‰—O¢‰‰‰›©‰‰‰—O‚‰‰‰›[‰‰‰—O¢‰‰‰å‰‰‰—O‚‰‰‰å‰‰‰—ó¢‰‰‰‰‰‰—ó‚‰‰‰›©‰‰‰—ó¢‰‰‰e‰‰‰—ó‚‰‰‰™]‰‰‰%¢‰‰‰‰‰‰%‚‰‰‰3‰‰‰%¢‰‰‰—‰‰‰%‚‰‰‰—‰‰‰é¢‰‰‰3‰‰‰é‚‰‰‰™]‰‰‰©M¢‰‰‰3‰‰‰©MÔ	©‰‰‰‹e‰‰‰‹edp‰`

--- a/test-output/de.thomas_oster.liblasercut.drivers.Ruida.out
+++ b/test-output/de.thomas_oster.liblasercut.drivers.Ruida.out
@@ -1,1 +1,1 @@
-Ò›úâ‹p	ým{ý‰z‹‰Ò‰p‰‰‰‰‰‰‰‰‰‰p‰‰‰õ‰‰‰‰‰p‰‰é‰‰…ùpÙ‰‰‰õ‰‰‰‰‰pY‰‰é‰‰…ùp‰	‰	‰‰‰‰‰‰‰‰‰‰p‰Ä«‹pÛ‰‰‰‰õ‰‰‰‰‰p[‰‰‰é‰‰…ùpi‰‰‰‰õ‰‰‰‰‰pë‰‰‰é‰‰…ùÐ9‰‰‰Ð»‰‰‰B‰‰‰5ÉÐé‰‰‰‰‰ýÄ‰‰‰‰‰íÄI‰‰Ä	‰Ä‹‰Ä	B‹‰‰5ÉÐ	‰‰Ð‹‰‰ÄÄ™‰‚‰‰‰õ‰‰‰õ¢‰‰	Ï±‰‰…ù¢‰‰…ù‰‰‰‰‰‚‰‰é‰‰‰‰‰¢‰‰[/‰‰‰/Ñ¢‰‰Û}‰‰	—é"‰{"w±m"‰;/Ñ¢‰‰[/‰‰‹m‘¢‰‰é‰‰…ùpÛ‰‰‰‰‰‰‰‡_p[‰‰‰‰U‰‰‰™]pi‰‰‰‰‰‰‰‡_pë‰‰‰‰U‰‰‰™]‚‰‰‰‰‰‰‡_¢‰‰‰q‰‰‰‡_¢‰‰‰W‰‰‰‡_¢‰‰‰›‰‰‰‡_¢‰‰‰£‰‰‰‡_¢‰‰‰U‰‰‰‡_‚‰‰‰U‰‰‰ƒ¢‰‰‰£‰‰‰ƒ¢‰‰‰M‰‰‰ƒ¢‰‰‰W‰‰‰ƒ¢‰‰‰¥‰‰‰ƒ¢‰‰‰‰‰‰ƒ‚‰‰‰‰‰‰5¢‰‰‰U‰‰‰5‚‰‰‰U‰‰‰ù¢‰‰‰q‰‰‰ù¢‰‰‰‰‰‰ù‚‰‰‰‰‰‰™«¢‰‰‰U‰‰‰™«‚‰‰‰U‰‰‰™]¢‰‰‰q‰‰‰™]¢‰‰‰‰‰‰™]pÛ‰‰‰‰™]‰‰‰—Op[‰‰‰‰—‰‰‰©Mpi‰‰‰‰™]‰‰‰—Opë‰‰‰‰—‰‰‰©M‚‰‰‰3‰‰‰—O¢‰‰‰›©‰‰‰—O‚‰‰‰›[‰‰‰—O¢‰‰‰å‰‰‰—O‚‰‰‰å‰‰‰—ó¢‰‰‰‰‰‰—ó‚‰‰‰›©‰‰‰—ó¢‰‰‰e‰‰‰—ó‚‰‰‰™]‰‰‰%¢‰‰‰‰‰‰%‚‰‰‰3‰‰‰%¢‰‰‰—‰‰‰%‚‰‰‰—‰‰‰é¢‰‰‰3‰‰‰é‚‰‰‰™]‰‰‰©M¢‰‰‰3‰‰‰©MÔ	©‰‰‰‹e‰‰‰‹edp‰`
+Ò›úâ‹p	ým{ý‰z‹‰Ò‰p‰‰‰‰‰‰‰‰‰‰p‰‰‰õ‰‰‰‰‰p‰‰é‰‰…ùpÙ‰‰‰õ‰‰‰‰‰pY‰‰é‰‰…ùp‰	‰	‰‰‰‰‰‰‰‰‰‰p‰Ä«‹pÛ‰‰‰‰õ‰‰‰‰‰p[‰‰‰é‰‰…ùpi‰‰‰‰õ‰‰‰‰‰pë‰‰‰é‰‰…ùÐ9‰‰‰Ð»‰‰‰B‰‰‰5ÉÐé‰‰‰‰‰ýÄ‰‰‰‰‰íÄI‰‰Ä	‰Ä‹‰Ä	B‹‰‰5ÉÐ	‰‰Ð‹‰‰ÄÄ™‰‚‰‰‰õ‰‰‰õ¢‰‰	Ï±‰‰…ù¢‰‰…ù‰‰‰‰‰‚‰‰é‰‰‰‰‰¢‰‰[/‰‰‰/Ñ¢‰‰Û}‰‰	—é"‰{"w±m"‰;/Ñ¢‰‰[/‰‰‹m‘¢‰‰é‰‰…ùpÛ‰‰‰‰‰‰‰‡_p[‰‰‰‰U‰‰‰™]pi‰‰‰‰‰‰‰‡_pë‰‰‰‰U‰‰‰™]‚‰‰‰‰‰‰‡_¢‰‰‰q‰‰‰‡_¢‰‰‰W‰‰‰‡_¢‰‰‰›‰‰‰‡_¢‰‰‰£‰‰‰‡_¢‰‰‰U‰‰‰‡_‚‰‰‰U‰‰‰ƒ¢‰‰‰£‰‰‰ƒ¢‰‰‰M‰‰‰ƒ¢‰‰‰W‰‰‰ƒ¢‰‰‰¥‰‰‰ƒ¢‰‰‰‰‰‰ƒ‚‰‰‰‰‰‰5¢‰‰‰U‰‰‰5‚‰‰‰U‰‰‰ù¢‰‰‰q‰‰‰ù¢‰‰‰‰‰‰ù‚‰‰‰‰‰‰™«¢‰‰‰U‰‰‰™«‚‰‰‰U‰‰‰™]¢‰‰‰q‰‰‰™]¢‰‰‰‰‰‰™]pÛ‰‰‰‰™]‰‰‰—Op[‰‰‰‰—‰‰‰©Mpi‰‰‰‰™]‰‰‰—Opë‰‰‰‰—‰‰‰©M‚‰‰‰3‰‰‰—O¢‰‰‰›©‰‰‰—O‚‰‰‰›[‰‰‰—O¢‰‰‰å‰‰‰—O‚‰‰‰å‰‰‰—ó¢‰‰‰‰‰‰—ó‚‰‰‰›©‰‰‰—ó¢‰‰‰e‰‰‰—ó‚‰‰‰™]‰‰‰%¢‰‰‰‰‰‰%‚‰‰‰3‰‰‰%¢‰‰‰—‰‰‰%‚‰‰‰—‰‰‰é¢‰‰‰3‰‰‰é‚‰‰‰™]‰‰‰©M¢‰‰‰3‰‰‰©MÔ	©‰‰‰‹e‰‰‰‹ep‰`

--- a/test-output/de.thomas_oster.liblasercut.drivers.Ruida.out
+++ b/test-output/de.thomas_oster.liblasercut.drivers.Ruida.out
@@ -1,1 +1,1 @@
-Ò›úâ‹p	ým{ý‰z‹‰Ò‰p‰‰‰‰‰‰‰‰‰‰p‰‰‰õ‰‰‰‰‰p‰‰é‰‰…ùpÙ‰‰‰õ‰‰‰‰‰pY‰‰é‰‰…ùp‰	‰	‰‰‰‰‰‰‰‰‰‰p‰Ä«‹pÛ‰‰‰‰õ‰‰‰‰‰p[‰‰‰é‰‰…ùpi‰‰‰‰õ‰‰‰‰‰pë‰‰‰é‰‰…ùÐ9‰‰‰Ð»‰‰‰B‰‰‰5ÉÐé‰‰‰‰‰ýÄ‰‰‰‰‰íÄI‰‰Ä	‰Ä‹‰Ä	B‹‰‰5ÉÐ	‰‰Ð‹‰‰ÄÄ™‰‚‰‰‰õ‰‰‰õ¢‰‰	Ï±‰‰…ù¢‰‰…ù‰‰‰‰‰‚‰‰é‰‰‰‰‰¢‰‰[/‰‰‰/Ñ¢‰‰Û}‰‰	—é"‰{"w±m"‰;/Ñ¢‰‰[/‰‰‹m‘¢‰‰é‰‰…ùpÛ‰‰‰‰‰‰‰‡_p[‰‰‰‰U‰‰‰™]pi‰‰‰‰‰‰‰‡_pë‰‰‰‰U‰‰‰™]‚‰‰‰‰‰‰‡_¢‰‰‰q‰‰‰‡_¢‰‰‰W‰‰‰‡_¢‰‰‰›‰‰‰‡_¢‰‰‰£‰‰‰‡_¢‰‰‰U‰‰‰‡_‚‰‰‰U‰‰‰ƒ¢‰‰‰£‰‰‰ƒ¢‰‰‰M‰‰‰ƒ¢‰‰‰W‰‰‰ƒ¢‰‰‰¥‰‰‰ƒ¢‰‰‰‰‰‰ƒ‚‰‰‰‰‰‰5¢‰‰‰U‰‰‰5‚‰‰‰U‰‰‰ù¢‰‰‰q‰‰‰ù¢‰‰‰‰‰‰ù‚‰‰‰‰‰‰™«¢‰‰‰U‰‰‰™«‚‰‰‰U‰‰‰™]¢‰‰‰q‰‰‰™]¢‰‰‰‰‰‰™]pÛ‰‰‰‰™]‰‰‰—Op[‰‰‰‰—‰‰‰©Mpi‰‰‰‰™]‰‰‰—Opë‰‰‰‰—‰‰‰©M‚‰‰‰3‰‰‰—O¢‰‰‰›©‰‰‰—O‚‰‰‰›[‰‰‰—O¢‰‰‰å‰‰‰—O‚‰‰‰å‰‰‰—ó¢‰‰‰‰‰‰—ó‚‰‰‰›©‰‰‰—ó¢‰‰‰e‰‰‰—ó‚‰‰‰™]‰‰‰%¢‰‰‰‰‰‰%‚‰‰‰3‰‰‰%¢‰‰‰—‰‰‰%‚‰‰‰—‰‰‰é¢‰‰‰3‰‰‰é‚‰‰‰™]‰‰‰©M¢‰‰‰3‰‰‰©MÔ	©‰‰‰‹e‰‰‰‹ep‰`
+Ò›úâ‹p	ým{ý‰z‹‰Ò‰p‰‰‰‰‰‰‰‰‰‰p‰‰‰õ‰‰‰‰‰p‰‰é‰‰…ùpÙ‰‰‰õ‰‰‰‰‰pY‰‰é‰‰…ùp‰	‰	‰‰‰‰‰‰‰‰‰‰p‰Ä«‹pÛ‰‰‰‰õ‰‰‰‰‰p[‰‰‰é‰‰…ùpi‰‰‰‰õ‰‰‰‰‰pë‰‰‰é‰‰…ùÐ9‰‰‰Ð»‰‰‰B‰‰‰5ÉÐé‰‰‰‰‰ýÄ‰‰‰‰‰íÄI‰‰Ä	‰Ä‹‰Ä	B‹‰‰5ÉÐ	‰‰Ð‹‰‰ÄÄ™‰‚‰‰‰õ‰‰‰õ¢‰‰	Ï±‰‰…ù¢‰‰…ù‰‰‰‰‰‚‰‰é‰‰‰‰‰¢‰‰[/‰‰‰/Ñ¢‰‰Û}‰‰	—é"‰{"w±m"‰;/Ñ¢‰‰[/‰‰‹m‘¢‰‰é‰‰…ùpÛ	‰‰‰‰‰‰‡_p[	‰‰‰U‰‰‰™]pi	‰‰‰‰‰‰‡_pë	‰‰‰U‰‰‰™]Ð9	‰‰Ð»	‰‰B	‰‰5ÉÐé	‰‰‰‰ýÄ	‰‰‰‰íÄI	‹Ä		Ä‹	Ä	B‹‰‰5ÉÐ	‰‰Ð‹‰‰ÄÄ™‰‚‰‰‰‰‰‰‡_¢‰‰‰q‰‰‰‡_¢‰‰‰W‰‰‰‡_¢‰‰‰›‰‰‰‡_¢‰‰‰£‰‰‰‡_¢‰‰‰U‰‰‰‡_‚‰‰‰U‰‰‰ƒ¢‰‰‰£‰‰‰ƒ¢‰‰‰M‰‰‰ƒ¢‰‰‰W‰‰‰ƒ¢‰‰‰¥‰‰‰ƒ¢‰‰‰‰‰‰ƒ‚‰‰‰‰‰‰5¢‰‰‰U‰‰‰5‚‰‰‰U‰‰‰ù¢‰‰‰q‰‰‰ù¢‰‰‰‰‰‰ù‚‰‰‰‰‰‰™«¢‰‰‰U‰‰‰™«‚‰‰‰U‰‰‰™]¢‰‰‰q‰‰‰™]¢‰‰‰‰‰‰™]pÛ‹‰‰‰™]‰‰‰—Op[‹‰‰‰—‰‰‰©Mpi‹‰‰‰™]‰‰‰—Opë‹‰‰‰—‰‰‰©MÐ9‹‰‰Ð»‹‰‰B‹‰‰5ÉÐé‹‰‰‰‰ýÄ‹‰‰‰‰íÄI‹‹Ä		Ä‹‹Ä	B‹‰‰5ÉÐ	‰‰Ð‹‰‰ÄÄ™‰‚‰‰‰3‰‰‰—O¢‰‰‰›©‰‰‰—O‚‰‰‰›[‰‰‰—O¢‰‰‰å‰‰‰—O‚‰‰‰å‰‰‰—ó¢‰‰‰‰‰‰—ó‚‰‰‰›©‰‰‰—ó¢‰‰‰e‰‰‰—ó‚‰‰‰™]‰‰‰%¢‰‰‰‰‰‰%‚‰‰‰3‰‰‰%¢‰‰‰—‰‰‰%‚‰‰‰—‰‰‰é¢‰‰‰3‰‰‰é‚‰‰‰™]‰‰‰©M¢‰‰‰3‰‰‰©MÔ	©‰‰‰‹e‰‰‰‹ep‰`

--- a/test-output/de.thomas_oster.liblasercut.drivers.Ruida.out
+++ b/test-output/de.thomas_oster.liblasercut.drivers.Ruida.out
@@ -1,1 +1,1 @@
-Ò›úâ‹p	ým{ý‰z‹‰Ò‰p‰‰‰‰‰‰‰‰‰‰p‰‰‰õ‰‰‰‰‰p‰‰é‰‰…ùpÙ‰‰‰õ‰‰‰‰‰pY‰‰é‰‰…ùp‰	‰	‰‰‰‰‰‰‰‰‰‰p‰Ä«‹pÛ‰‰‰‰õ‰‰‰‰‰p[‰‰‰é‰‰…ùpi‰‰‰‰õ‰‰‰‰‰pë‰‰‰é‰‰…ùÐ9‰‰‰Ð»‰‰‰B‰‰‰5ÉÐé‰‰‰‰‰ýÄ‰‰‰‰‰íÄI‰‰Ä	‰Ä‹‰Ä	B‹‰‰‰áÐ	‰‰Ð‹‰‰ÄÄ™‰‚‰‰‰õ‰‰‰õ¢‰‰	Ï±‰‰…ù¢‰‰…ù‰‰‰‰‰‚‰‰é‰‰‰‰‰¢‰‰[/‰‰‰/Ñ¢‰‰Û}‰‰	—é"‰û"w?m"‰»/_¢‰‰[/‰‰‹m‘¢‰‰é‰‰…ùpÛ‰‰‰‰‰‰‰‰‰‡_p[‰‰‰	-…‰‰‰™]pi‰‰‰‰‰‰‰‰‰‡_pë‰‰‰	-…‰‰‰™]‚‰‰‰‰‰‰‰‰‡_„¤‰m¤‰m¤‰»¤	‘¤‰»‚‰‰	-…‰‰‰‡_‰»‚‰‰‰U‰‰‰ƒ¤wE¤w“¤w“¤wE¤÷o„óc‰»„¤A‚‰‰	-…‰‰‰5‰»‚‰‰‰U‰‰‰ù¤u•¤w“„óc‰»„¤A‚‰‰	-…‰‰‰™«‚‰‰	-…‰‰‰™]‚‰‰‰U‰‰‰™]¤u•¤w“„ócpÛ‰‰‰‰‰‰‰‰‰—Op[‰‰‰	¹E‰‰‰©Mpi‰‰‰‰‰‰‰‰‰—Opë‰‰‰	¹E‰‰‰©My„3¤‰m„‰»¤	‘‚‰‰	¹‰‰‰—O‰»‚‰‰‰å‰‰‰—ó¤w“„w“¤wE„ç›‰»„™]¤‰»‚‰‰‰3‰‰‰%¤‹k‚‰‰	¹E‰‰‰%‰»‚‰‰‰—‰‰‰é¤u•„çÍ‰m„™]¤‰m‚‰‰	%ã‰‰‰©MÔ	©‰‰‰Û‰‰‰Ûdp‰`
+Ò›úâ‹p	ým{ý‰z‹‰Ò‰p‰‰‰‰‰‰‰‰‰‰p‰‰‰õ‰‰‰‰‰p‰‰é‰‰…ùpÙ‰‰‰õ‰‰‰‰‰pY‰‰é‰‰…ùp‰	‰	‰‰‰‰‰‰‰‰‰‰p‰Ä«‹pÛ‰‰‰‰õ‰‰‰‰‰p[‰‰‰é‰‰…ùpi‰‰‰‰õ‰‰‰‰‰pë‰‰‰é‰‰…ùÐ9‰‰‰Ð»‰‰‰B‰‰‰5ÉÐé‰‰‰‰‰ýÄ‰‰‰‰‰íÄI‰‰Ä	‰Ä‹‰Ä	B‹‰‰‰áÐ	‰‰Ð‹‰‰ÄÄ™‰‚‰‰‰õ‰‰‰õ¢‰‰	Ï±‰‰…ù¢‰‰…ù‰‰‰‰‰‚‰‰é‰‰‰‰‰¢‰‰[/‰‰‰/Ñ¢‰‰Û}‰‰	—é"‰û"w?m"‰»/_¢‰‰[/‰‰‹m‘¢‰‰é‰‰…ùpÛ‰‰‰‰‰‰‰‡_p[‰‰‰‰U‰‰‰™]pi‰‰‰‰‰‰‰‡_pë‰‰‰‰U‰‰‰™]‚‰‰‰‰‰‰‡_¢‰‰‰q‰‰‰‡_¢‰‰‰W‰‰‰‡_¢‰‰‰›‰‰‰‡_¢‰‰‰£‰‰‰‡_¢‰‰‰U‰‰‰‡_‚‰‰‰U‰‰‰ƒ¢‰‰‰£‰‰‰ƒ¢‰‰‰M‰‰‰ƒ¢‰‰‰W‰‰‰ƒ¢‰‰‰¥‰‰‰ƒ¢‰‰‰‰‰‰ƒ‚‰‰‰‰‰‰5¢‰‰‰U‰‰‰5‚‰‰‰U‰‰‰ù¢‰‰‰q‰‰‰ù¢‰‰‰‰‰‰ù‚‰‰‰‰‰‰™«¢‰‰‰U‰‰‰™«‚‰‰‰U‰‰‰™]¢‰‰‰q‰‰‰™]¢‰‰‰‰‰‰™]pÛ‰‰‰‰™]‰‰‰—Op[‰‰‰‰—‰‰‰©Mpi‰‰‰‰™]‰‰‰—Opë‰‰‰‰—‰‰‰©M‚‰‰‰3‰‰‰—O¢‰‰‰›©‰‰‰—O‚‰‰‰›[‰‰‰—O¢‰‰‰å‰‰‰—O‚‰‰‰å‰‰‰—ó¢‰‰‰‰‰‰—ó‚‰‰‰›©‰‰‰—ó¢‰‰‰e‰‰‰—ó‚‰‰‰™]‰‰‰%¢‰‰‰‰‰‰%‚‰‰‰3‰‰‰%¢‰‰‰—‰‰‰%‚‰‰‰—‰‰‰é¢‰‰‰3‰‰‰é‚‰‰‰™]‰‰‰©M¢‰‰‰3‰‰‰©MÔ	©‰‰‰‹e‰‰‰‹edp‰`

--- a/test-output/de.thomas_oster.liblasercut.drivers.Ruida.out
+++ b/test-output/de.thomas_oster.liblasercut.drivers.Ruida.out
@@ -1,1 +1,1 @@
-Ò›úâ‹p	ým{ý‰z‹‰Ò‰p‰‰‰‰‰‰‰‰‰‰p‰‰‰õ‰‰‰‰‰p‰‰é‰‰…ùpÙ‰‰‰õ‰‰‰‰‰pY‰‰é‰‰…ùp‰	‰	‰‰‰‰‰‰‰‰‰‰p‰Ä«‹pÛ‰‰‰‰õ‰‰‰‰‰p[‰‰‰é‰‰…ùpi‰‰‰‰õ‰‰‰‰‰pë‰‰‰é‰‰…ùÐ9‰‰‰Ð»‰‰‰B‰‰‰5ÉÐé‰‰‰‰‰ýÄ‰‰‰‰‰íÄI‰‰Ä	‰Ä‹‰Ä	B‹‰‰‰áÐ	‰‰Ð‹‰‰ÄÄ™‰‚‰‰‰õ‰‰‰õ¢‰‰	Ï±‰‰…ù¢‰‰…ù‰‰‰‰‰‚‰‰é‰‰‰‰‰¢‰‰[/‰‰‰/Ñ¢‰‰Û}‰‰	—é"‰û"w?m"‰»/_¢‰‰[/‰‰‹m‘¢‰‰é‰‰…ùpÛ‰‰‰‰‰‰‰‡_p[‰‰‰‰U‰‰‰™]pi‰‰‰‰‰‰‰‡_pë‰‰‰‰U‰‰‰™]‚‰‰‰‰‰‰‡_¢‰‰‰q‰‰‰‡_¢‰‰‰W‰‰‰‡_¢‰‰‰›‰‰‰‡_¢‰‰‰£‰‰‰‡_¢‰‰‰U‰‰‰‡_‚‰‰‰U‰‰‰ƒ¢‰‰‰£‰‰‰ƒ¢‰‰‰M‰‰‰ƒ¢‰‰‰W‰‰‰ƒ¢‰‰‰¥‰‰‰ƒ¢‰‰‰‰‰‰ƒ‚‰‰‰‰‰‰5¢‰‰‰U‰‰‰5‚‰‰‰U‰‰‰ù¢‰‰‰q‰‰‰ù¢‰‰‰‰‰‰ù‚‰‰‰‰‰‰™«¢‰‰‰U‰‰‰™«‚‰‰‰U‰‰‰™]¢‰‰‰q‰‰‰™]¢‰‰‰‰‰‰™]pÛ‰‰‰‰™]‰‰‰—Op[‰‰‰‰—‰‰‰©Mpi‰‰‰‰™]‰‰‰—Opë‰‰‰‰—‰‰‰©M‚‰‰‰3‰‰‰—O¢‰‰‰›©‰‰‰—O‚‰‰‰›[‰‰‰—O¢‰‰‰å‰‰‰—O‚‰‰‰å‰‰‰—ó¢‰‰‰‰‰‰—ó‚‰‰‰›©‰‰‰—ó¢‰‰‰e‰‰‰—ó‚‰‰‰™]‰‰‰%¢‰‰‰‰‰‰%‚‰‰‰3‰‰‰%¢‰‰‰—‰‰‰%‚‰‰‰—‰‰‰é¢‰‰‰3‰‰‰é‚‰‰‰™]‰‰‰©M¢‰‰‰3‰‰‰©MÔ	©‰‰‰‹e‰‰‰‹edp‰`
+Ò›úâ‹p	ým{ý‰z‹‰Ò‰p‰‰‰‰‰‰‰‰‰‰p‰‰‰õ‰‰‰‰‰p‰‰é‰‰…ùpÙ‰‰‰õ‰‰‰‰‰pY‰‰é‰‰…ùp‰	‰	‰‰‰‰‰‰‰‰‰‰p‰Ä«‹pÛ‰‰‰‰õ‰‰‰‰‰p[‰‰‰é‰‰…ùpi‰‰‰‰õ‰‰‰‰‰pë‰‰‰é‰‰…ùÐ9‰‰‰Ð»‰‰‰B‰‰‰5ÉÐé‰‰‰‰‰ýÄ‰‰‰‰‰íÄI‰‰Ä	‰Ä‹‰Ä	B‹‰‰5ÉÐ	‰‰Ð‹‰‰ÄÄ™‰‚‰‰‰õ‰‰‰õ¢‰‰	Ï±‰‰…ù¢‰‰…ù‰‰‰‰‰‚‰‰é‰‰‰‰‰¢‰‰[/‰‰‰/Ñ¢‰‰Û}‰‰	—é"‰û"w?m"‰»/_¢‰‰[/‰‰‹m‘¢‰‰é‰‰…ùpÛ‰‰‰‰‰‰‰‡_p[‰‰‰‰U‰‰‰™]pi‰‰‰‰‰‰‰‡_pë‰‰‰‰U‰‰‰™]‚‰‰‰‰‰‰‡_¢‰‰‰q‰‰‰‡_¢‰‰‰W‰‰‰‡_¢‰‰‰›‰‰‰‡_¢‰‰‰£‰‰‰‡_¢‰‰‰U‰‰‰‡_‚‰‰‰U‰‰‰ƒ¢‰‰‰£‰‰‰ƒ¢‰‰‰M‰‰‰ƒ¢‰‰‰W‰‰‰ƒ¢‰‰‰¥‰‰‰ƒ¢‰‰‰‰‰‰ƒ‚‰‰‰‰‰‰5¢‰‰‰U‰‰‰5‚‰‰‰U‰‰‰ù¢‰‰‰q‰‰‰ù¢‰‰‰‰‰‰ù‚‰‰‰‰‰‰™«¢‰‰‰U‰‰‰™«‚‰‰‰U‰‰‰™]¢‰‰‰q‰‰‰™]¢‰‰‰‰‰‰™]pÛ‰‰‰‰™]‰‰‰—Op[‰‰‰‰—‰‰‰©Mpi‰‰‰‰™]‰‰‰—Opë‰‰‰‰—‰‰‰©M‚‰‰‰3‰‰‰—O¢‰‰‰›©‰‰‰—O‚‰‰‰›[‰‰‰—O¢‰‰‰å‰‰‰—O‚‰‰‰å‰‰‰—ó¢‰‰‰‰‰‰—ó‚‰‰‰›©‰‰‰—ó¢‰‰‰e‰‰‰—ó‚‰‰‰™]‰‰‰%¢‰‰‰‰‰‰%‚‰‰‰3‰‰‰%¢‰‰‰—‰‰‰%‚‰‰‰—‰‰‰é¢‰‰‰3‰‰‰é‚‰‰‰™]‰‰‰©M¢‰‰‰3‰‰‰©MÔ	©‰‰‰‹e‰‰‰‹edp‰`


### PR DESCRIPTION
Fix a few bugs in the Ruida driver:
- Fix 0xC902 speed conversion
- Calculate speed percentage from maximum cutting speed (#190)
- Remove unnecessary array stop command
- Fix layer property code generation (#194)
- Force movement if last position is unknown (#189)
- Add missing reset of instance variables