### PR TITLE
Support X and Y axis flip

### DIFF
--- a/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
@@ -92,6 +92,8 @@ public class Ruida extends LaserCutter
   protected static final String SETTING_MAX_POWER = "Max laser power (%)";
   protected static final String SETTING_BED_WIDTH = "Bed width (mm)";
   protected static final String SETTING_BED_HEIGHT = "Bed height (mm)";
+  protected static final String SETTING_FLIP_X = "Flip X Axis";
+  protected static final String SETTING_FLIP_Y = "Flip Y Axis";
   protected static final Locale FORMAT_LOCALE = Locale.US;
 
   protected static final String[] uploadMethodList = {UPLOAD_METHOD_FILE, UPLOAD_METHOD_IP, UPLOAD_METHOD_SERIAL};
@@ -136,6 +138,30 @@ public class Ruida extends LaserCutter
   public void setComport(String comport)
   {
     this.comport = comport;
+  }
+
+  protected boolean flipXaxis = false;
+
+  public boolean isFlipXaxis()
+  {
+    return flipXaxis;
+  }
+
+  public void setFlipXaxis(boolean flipXaxis)
+  {
+    this.flipXaxis = flipXaxis;
+  }
+
+  protected boolean flipYaxis = false;
+
+  public boolean isFlipYaxis()
+  {
+    return flipYaxis;
+  }
+
+  public void setFlipYaxis(boolean flipYaxis)
+  {
+    this.flipYaxis = flipYaxis;
   }
 
   /* -----------------------------------------------------------------------*/
@@ -267,8 +293,8 @@ public class Ruida extends LaserCutter
 
   private void vector(double x, double y, double dpi, boolean as_cut, boolean force_abs) throws IOException
   {
-    double x_mm = Util.px2mm(x, dpi);
-    double y_mm = Util.px2mm(y, dpi);
+    double x_mm = isFlipXaxis() ? getBedWidth() - Util.px2mm(x, dpi) : Util.px2mm(x, dpi);
+    double y_mm = isFlipYaxis() ? getBedHeight() - Util.px2mm(y, dpi) : Util.px2mm(y, dpi);
     boolean as_absolute;
 
     /* compute distance to last known position */
@@ -935,6 +961,8 @@ public class Ruida extends LaserCutter
     SETTING_MAX_POWER,
     SETTING_BED_WIDTH,
     SETTING_BED_HEIGHT,
+    SETTING_FLIP_X,
+    SETTING_FLIP_Y,
   };
 
   @Override
@@ -961,6 +989,10 @@ public class Ruida extends LaserCutter
       return this.getBedWidth();
     } else if (SETTING_BED_HEIGHT.equals(attribute)) {
       return this.getBedHeight();
+    } else if (SETTING_FLIP_X.equals(attribute)) {
+      return this.isFlipXaxis();
+    } else if (SETTING_FLIP_Y.equals(attribute)) {
+      return this.isFlipYaxis();
     }
     return null;
   }
@@ -994,6 +1026,10 @@ public class Ruida extends LaserCutter
       this.setBedHeigth((Double)value);
     } else if (SETTING_BED_WIDTH.equals(attribute)) {
       this.setBedWidth((Double)value);
+    } else if (SETTING_FLIP_X.equals(attribute)) {
+      this.setFlipXaxis((Boolean) value);
+    } else if (SETTING_FLIP_Y.equals(attribute)) {
+      this.setFlipYaxis((Boolean) value);
     }
   }
 


### PR DESCRIPTION
Introduce two new settings

* `Flip X Axis`
* `Flip Y Axis`

to support lasercutters with a non-standard (not "top left") origin.

Fixes #198 