### PR TITLE
Fix class's package path

### DIFF
--- a/src/main/java/de/thomas_oster/liblasercut/FloatMinMaxPowerSpeedFrequencyProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/FloatMinMaxPowerSpeedFrequencyProperty.java
@@ -17,10 +17,9 @@
  * along with LibLaserCut. If not, see <http://www.gnu.org/licenses/>.
  *
  **/
-package de.thomas_oster.liblasercut.drivers;
 
-import de.thomas_oster.liblasercut.LaserProperty;
-import de.thomas_oster.liblasercut.FloatPowerSpeedFrequencyProperty;
+package de.thomas_oster.liblasercut;
+
 import java.util.Arrays;
 import java.util.LinkedList;
 


### PR DESCRIPTION
Apparently, this was an oversight during some refactoring. The builds work nevertheless (most likely a warning is issued), but IDEs rightfully complain about this.