### PR TITLE
GenericGcodeDriver/Grbl: Fix for flip-setting also translating by bed width/height when startpoint is set

### DIFF
--- a/src/main/java/de/thomas_oster/liblasercut/drivers/Grbl.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/Grbl.java
@@ -163,9 +163,9 @@ public class Grbl extends GenericGcodeDriver
    * Doesn't include travel speed since grbl ignores that anyway.
    */
   @Override
-  protected void move(PrintStream out, double x, double y, double resolution) throws IOException {
-    x = isFlipXaxis() ? getBedWidth() - Util.px2mm(x, resolution) : Util.px2mm(x, resolution);
-    y = isFlipYaxis() ? getBedHeight() - Util.px2mm(y, resolution) : Util.px2mm(y, resolution);
+  protected void move(PrintStream out, double x, double y, double resolution, boolean flipShouldAlsoTranslate) throws IOException {
+    x = isFlipXaxis() ? (flipShouldAlsoTranslate ? getBedWidth() : 0) - Util.px2mm(x, resolution) : Util.px2mm(x, resolution);
+    y = isFlipYaxis() ? (flipShouldAlsoTranslate ? getBedHeight() : 0) - Util.px2mm(y, resolution) : Util.px2mm(y, resolution);
     currentSpeed = getTravel_speed();
     if (blankLaserDuringRapids)
     {


### PR DESCRIPTION
We tried to use the "set startpoint" function to support the use case for jogging to the start point and set work-coordinates to zero. But our Y-coordinate also uses the flip-setting. The problem is, that this setting incorrectly still adds the bed height to the coordinates when flipping when the starting-point is set. This PR fixes this.

I can't imagine a use-case where the translate by bed-height when a startpoint is set is useful. Under this assumption, I consider this PR as backwards compatible.